### PR TITLE
docs: add per-project documentation for SDK, Azure plugin, and restructure root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,32 @@
 
 Classify Terraform plan changes based on organization-defined rules. tfclassify analyzes `terraform show -json` output and categorizes each resource change (critical, review, standard, auto-approved, etc.) so you can automate change approval workflows.
 
-## How it works
+## Table of Contents
+
+- [How It Works](#how-it-works)
+- [Quick Start](#quick-start)
+- [CLI Reference](#cli-reference)
+  - [Root Command](#root-command)
+  - [Init Command](#init-command)
+  - [Output Formats](#output-formats)
+- [Configuration](#configuration)
+  - [Config Discovery](#config-discovery)
+  - [Classification Rules](#classification-rules)
+  - [Rule Fields](#rule-fields)
+  - [Precedence](#precedence)
+  - [Defaults](#defaults)
+  - [Plugin Declarations](#plugin-declarations)
+- [Plan File Formats](#plan-file-formats)
+- [Three-Layer Classification Model](#three-layer-classification-model)
+  - [Layer 1: Core Rules](#layer-1-core-rules)
+  - [Layer 2: Builtin Analyzers](#layer-2-builtin-analyzers)
+  - [Layer 3: Deep Inspection Plugins](#layer-3-deep-inspection-plugins)
+- [Examples](#examples)
+- [Project Structure](#project-structure)
+- [Development](#development)
+- [Architecture Decisions](#architecture-decisions)
+
+## How It Works
 
 1. You define classification rules in `.tfclassify.hcl` using glob patterns on resource types and actions
 2. tfclassify parses a Terraform plan and evaluates each resource change against your rules
@@ -27,7 +52,7 @@ Exit codes map to precedence position, making tfclassify usable as a gate in CI/
 | ... | ... | ... |
 | Last (lowest) | 0 | Auto — proceed |
 
-## Quick start
+## Quick Start
 
 ### Build
 
@@ -41,15 +66,24 @@ make build
 Create `.tfclassify.hcl` in your project root:
 
 ```hcl
+# "critical" — any deletion of identity/access resources.
+# The "resource" field accepts glob patterns matched against the Terraform
+# resource type (e.g. "azurerm_role_assignment", "aws_iam_role").
 classification "critical" {
   description = "Requires security team approval"
 
   rule {
     resource = ["*_role_*", "*_iam_*"]
     actions  = ["delete"]
+    # Matches: azurerm_role_assignment being DELETED
+    # Skips:   azurerm_role_assignment being created or updated
   }
 }
 
+# "standard" — everything not caught above.
+# Using resource = ["*"] as a catch-all is safe because the classifier evaluates
+# rules in precedence order: critical is checked first, so this only catches
+# resources that didn't match anything above.
 classification "standard" {
   description = "Standard change process"
 
@@ -58,6 +92,7 @@ classification "standard" {
   }
 }
 
+# "auto" — no-op changes (Terraform evaluated but found no changes).
 classification "auto" {
   description = "Automatic approval"
 
@@ -67,15 +102,15 @@ classification "auto" {
   }
 }
 
+# Precedence controls evaluation order AND exit codes.
+# Exit codes: auto=0, standard=1, critical=2
 precedence = ["critical", "standard", "auto"]
 
 defaults {
-  unclassified = "standard"
-  no_changes   = "auto"
+  unclassified = "standard"   # Resources matching no rule
+  no_changes   = "auto"       # Plans with zero resource changes
 }
 ```
-
-Rules are evaluated in precedence order. `resource = ["*"]` on `standard` is safe as a catch-all because `critical` is checked first.
 
 ### Run
 
@@ -106,7 +141,9 @@ Resources: 3
     Rule: standard rule 1 (resource: *)
 ```
 
-## CLI reference
+## CLI Reference
+
+### Root Command
 
 ```
 tfclassify [flags]
@@ -119,15 +156,58 @@ tfclassify [flags]
 | `--output` | `-o` | `text` | Output format: `text`, `json`, `github` |
 | `--verbose` | `-v` | `false` | Show per-resource rule match details |
 
+### Init Command
+
+```
+tfclassify init [flags]
+```
+
+Downloads and installs plugin binaries declared in your configuration from GitHub releases.
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--config` | `-c` | auto-discover | Path to `.tfclassify.hcl` config file |
+
+Supports `GITHUB_TOKEN` environment variable for authenticated requests.
+
+### Output Formats
+
+**Text** (default) — human-readable summary. With `-v`, groups resources by classification and shows matched rules.
+
+**JSON** — machine-readable output for CI/CD integration:
+
+```json
+{
+  "overall": "critical",
+  "overall_description": "Requires security team approval",
+  "exit_code": 2,
+  "no_changes": false,
+  "resources": [
+    {
+      "address": "azurerm_role_assignment.admin",
+      "type": "azurerm_role_assignment",
+      "actions": ["delete"],
+      "classification": "critical",
+      "classification_description": "Requires security team approval",
+      "matched_rule": "critical rule 1 (resource: *_role_*, ...)"
+    }
+  ]
+}
+```
+
+**GitHub** — sets GitHub Actions output variables (`classification`, `exit_code`, `no_changes`, `resource_count`) in both legacy `::set-output` and `GITHUB_OUTPUT` file formats.
+
 ## Configuration
 
-tfclassify uses HCL configuration (`.tfclassify.hcl`). Config files are discovered in order:
+### Config Discovery
+
+Config files are discovered in order:
 
 1. Explicit path via `--config`
 2. `.tfclassify.hcl` in the current directory
 3. `.tfclassify.hcl` in the home directory
 
-### Classification rules
+### Classification Rules
 
 Each `classification` block contains one or more `rule` blocks. A resource matches a classification if it matches **any** of its rules.
 
@@ -147,13 +227,23 @@ classification "review" {
 }
 ```
 
-**Rule fields:**
+### Rule Fields
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `resource` | list of globs | Resource type must match at least one pattern |
-| `not_resource` | list of globs | Resource type must match none of the patterns |
-| `actions` | list of strings | Terraform action must be one of these (`create`, `update`, `delete`, `read`, `no-op`). Omit to match all actions |
+| `description` | string | Optional. Appears in verbose/JSON output explaining why the rule matched. |
+| `resource` | list of globs | Resource type must match at least one pattern. |
+| `not_resource` | list of globs | Resource type must match **none** of the patterns. Cannot combine with `resource` in the same rule. |
+| `actions` | list of strings | Terraform action must be one of: `create`, `update`, `delete`, `read`, `no-op`. Omit to match all actions. |
+
+Glob patterns use `*` to match any sequence of characters. Some useful patterns:
+
+| Pattern | Matches | Does Not Match |
+|---------|---------|----------------|
+| `*_role_*` | `azurerm_role_assignment`, `aws_iam_role_policy` | `azurerm_resource_group` |
+| `*_key_vault` | `azurerm_key_vault` | `azurerm_key_vault_secret` |
+| `*_key_vault_*` | `azurerm_key_vault_secret`, `azurerm_key_vault_key` | `azurerm_key_vault` |
+| `*` | Everything | — |
 
 ### Precedence
 
@@ -167,16 +257,40 @@ precedence = ["critical", "review", "standard", "auto"]
 # Exit codes:  3          2         1           0
 ```
 
+The overall exit code is the highest across all resources. One critical resource makes the entire plan exit 3.
+
 ### Defaults
 
 ```hcl
 defaults {
-  unclassified = "standard"   # Resources matching no rule
-  no_changes   = "auto"       # Plans with zero resource changes
+  unclassified   = "standard"   # Resources matching no rule
+  no_changes     = "auto"       # Plans with zero resource changes
+  plugin_timeout = "30s"        # Timeout for external plugin execution
 }
 ```
 
-## Plan file formats
+`unclassified` and `no_changes` must reference classification names from the precedence list. `plugin_timeout` accepts Go duration strings (e.g. `"10s"`, `"2m30s"`).
+
+### Plugin Declarations
+
+```hcl
+plugin "azurerm" {
+  enabled = true
+  source  = "github.com/jokarl/tfclassify"   # GitHub repo for download
+  version = "0.1.0"                            # Semantic version
+
+  config {
+    # Plugin-specific options (opaque to core, forwarded via gRPC)
+    privilege_enabled = true
+    network_enabled   = true
+    keyvault_enabled  = true
+  }
+}
+```
+
+See the [full-reference example](docs/examples/full-reference/.tfclassify.hcl) for an annotated configuration demonstrating every field.
+
+## Plan File Formats
 
 tfclassify accepts both JSON and binary Terraform plan files:
 
@@ -185,7 +299,9 @@ tfclassify accepts both JSON and binary Terraform plan files:
 | JSON | `terraform show -json tfplan > plan.json` | First byte is `{` |
 | Binary | `terraform plan -out=tfplan` | ZIP magic bytes (`PK`) |
 
-When a binary plan is detected, tfclassify automatically invokes `terraform show -json` to convert it. The `terraform` binary must be on PATH (or set `TERRAFORM_PATH` env var).
+Supported format versions: `0.2`, `1.0`, `1.1`, `1.2`.
+
+When a binary plan is detected, tfclassify automatically invokes `terraform show -json` to convert it. The `terraform` (or `tofu`) binary must be on PATH, or set via `TERRAFORM_PATH` env var.
 
 ```bash
 # Direct binary plan support — no manual conversion needed
@@ -193,33 +309,17 @@ terraform plan -out=tfplan
 tfclassify -p tfplan
 ```
 
-## Plugin system
+## Three-Layer Classification Model
 
-tfclassify supports plugins for deep inspection beyond pattern matching. Plugins run as separate processes communicating over gRPC.
+tfclassify classifies resources through three progressively deeper layers:
 
-### Installing plugins
+### Layer 1: Core Rules
 
-External plugins are installed using `tfclassify init`, which reads plugin declarations from your config and downloads binaries from GitHub releases:
+Config-driven pattern matching. Glob patterns on resource types and actions, evaluated against the precedence order from `.tfclassify.hcl`. This is the fast path — no plugins involved.
 
-```bash
-tfclassify init
-```
+### Layer 2: Builtin Analyzers
 
-Example config with an external plugin:
-
-```hcl
-plugin "azurerm" {
-  enabled = true
-  source  = "github.com/jokarl/tfclassify-plugin-azurerm"
-  version = "0.1.0"
-}
-```
-
-Plugin binaries are placed in `.tfclassify/plugins/` (or `TFCLASSIFY_PLUGIN_DIR`).
-
-### Builtin analyzers
-
-tfclassify includes three cross-provider analyzers that run in-process (no plugin required):
+Cross-provider heuristics that run in-process after core rules. These detect Terraform-level concepts regardless of provider:
 
 | Analyzer | Detects | Severity |
 |----------|---------|----------|
@@ -227,85 +327,114 @@ tfclassify includes three cross-provider analyzers that run in-process (no plugi
 | `replace` | Resource replacements (destroy + recreate) | 75 |
 | `sensitive` | Changes to Terraform-marked sensitive attributes | 70 |
 
-These are enabled by default and operate on Terraform-level concepts (actions, sensitive markers) rather than provider-specific semantics.
+Builtin analyzers are always enabled and require no configuration.
 
-### Example plugin: azurerm
+### Layer 3: Deep Inspection Plugins
 
-The `azurerm` plugin in `plugins/azurerm/` demonstrates deep inspection (Layer 3) analysis for Azure resources. It includes three analyzers:
+Provider-specific analysis via external plugins. Plugins run as separate processes communicating over gRPC ([hashicorp/go-plugin](https://github.com/hashicorp/go-plugin)). They inspect actual resource attribute values — role permissions, network CIDRs, access grants — to produce graduated severity scores.
 
-| Analyzer | Detects | Severity |
-|----------|---------|----------|
-| `privilege-escalation` | Role changes with permission-based severity scoring (e.g., Reader → Owner) | 40-95 (graduated) |
-| `network-exposure` | Permissive network rules (0.0.0.0/0, *, Internet) | 85 |
-| `key-vault-access` | Destructive Key Vault permissions (purge, delete) | 80 |
+**Available plugins:**
 
-The privilege escalation analyzer uses an embedded database of 400+ Azure built-in roles with full permission sets, scope-based weighting (management group > subscription > resource group > resource), and cross-references custom role definitions from the Terraform plan.
+| Plugin | Documentation | Detects |
+|--------|--------------|---------|
+| [azurerm](plugins/azurerm/) | [plugins/azurerm/README.md](plugins/azurerm/README.md) | Privilege escalation, network exposure, destructive key vault permissions |
 
-See the [plugin authoring guide](docs/plugin-authoring.md) for details on building custom plugins.
-
-### Plugin discovery
-
-External plugins are discovered as `tfclassify-plugin-{name}` binaries in:
+**Plugin discovery:** plugins are discovered as `tfclassify-plugin-{name}` binaries in:
 
 1. `TFCLASSIFY_PLUGIN_DIR` environment variable
 2. `.tfclassify/plugins/` in the current directory
 3. `~/.tfclassify/plugins/` in the home directory
 
+**Decision aggregation:** plugin decisions are merged with core results via the precedence system. A plugin can escalate a resource's classification but never lower it.
+
+**Building custom plugins:** see the [Plugin SDK documentation](sdk/README.md) and [plugin authoring guide](docs/plugin-authoring.md).
+
 ## Examples
 
-Working examples with sample plan JSON and expected output:
+Working examples with sample plan JSON, annotated config files, and expected output:
 
 | Example | Demonstrates |
 |---------|-------------|
-| [basic-classification](docs/examples/basic-classification/) | Resource type glob matching, `not_resource` exclusion, exit codes |
-| [action-filtering](docs/examples/action-filtering/) | Action-specific rules, same type with different classifications |
-| [mixed-changes](docs/examples/mixed-changes/) | Multiple rules per classification, glob precision, sensitive attributes |
+| [basic-classification](docs/examples/basic-classification/) | Resource type glob matching, `resource = ["*"]` catch-all, exit codes |
+| [action-filtering](docs/examples/action-filtering/) | Action-specific rules, same type with different classifications based on action |
+| [mixed-changes](docs/examples/mixed-changes/) | Multiple rules per classification, glob precision (`*_key_vault` vs `*_key_vault_*`) |
+| [full-reference](docs/examples/full-reference/) | Every configurable field annotated: plugins, `not_resource`, `plugin_timeout`, five precedence levels |
 
-Each example directory contains a `.tfclassify.hcl`, a `plan.json`, and a `README.md` with run instructions and expected output.
+Each example directory contains a `.tfclassify.hcl`, a `plan.json`, and a `README.md` with run instructions and expected output. Run any example:
 
-## Project structure
+```bash
+tfclassify \
+  -p docs/examples/basic-classification/plan.json \
+  -c docs/examples/basic-classification/.tfclassify.hcl \
+  -v
+```
+
+## Project Structure
+
+The repository uses Go workspaces (`go.work`) with three modules:
+
+| Module | Path | Documentation | Purpose |
+|--------|------|---------------|---------|
+| `github.com/jokarl/tfclassify` | `.` | This file | CLI, core engine, config, plan parsing, plugin host |
+| `github.com/jokarl/tfclassify/sdk` | [`sdk/`](sdk/) | [sdk/README.md](sdk/README.md) | Plugin authoring SDK (Analyzer, Runner, PluginSet interfaces) |
+| `github.com/jokarl/tfclassify-plugin-azurerm` | [`plugins/azurerm/`](plugins/azurerm/) | [plugins/azurerm/README.md](plugins/azurerm/README.md) | Azure deep inspection plugin |
 
 ```
 tfclassify/
 ├── cmd/tfclassify/        # CLI entry point (Cobra)
 ├── pkg/
-│   ├── classify/          # Core classification engine (precedence-ordered rule evaluation)
-│   ├── config/            # HCL config loading, validation, and discovery
+│   ├── classify/          # Core classification engine (Layer 1 + 2)
+│   ├── config/            # HCL config loading, validation, discovery
 │   ├── output/            # Output formatters (text, json, github)
-│   ├── plan/              # Terraform plan JSON parsing
-│   └── plugin/            # Plugin discovery and lifecycle management
-├── sdk/                   # Public plugin SDK (Analyzer, Runner, PluginSet interfaces)
-│   └── plugin/            # Plugin gRPC server entry point
+│   ├── plan/              # Terraform plan JSON/binary parsing
+│   └── plugin/            # Plugin discovery, installation, lifecycle
+├── sdk/                   # Plugin SDK — see sdk/README.md
+│   ├── plugin/            # gRPC plugin server entry point
+│   └── pb/                # Generated protobuf code
 ├── plugins/
-│   └── azurerm/           # Example Azure deep inspection plugin (privilege, network, keyvault)
+│   └── azurerm/           # Azure plugin — see plugins/azurerm/README.md
 ├── proto/                 # gRPC protocol definitions
-└── docs/
-    ├── adr/               # Architecture Decision Records
-    ├── cr/                # Change Requests
-    └── examples/          # Working examples with sample plans
+├── docs/
+│   ├── adr/               # Architecture Decision Records
+│   ├── cr/                # Change Requests
+│   ├── examples/          # Working examples with sample plans
+│   └── plugin-authoring.md
+├── go.work                # Go workspace tying all three modules together
+└── Makefile
 ```
-
-The repository uses Go workspaces (`go.work`) with three modules:
-
-| Module | Path | Purpose |
-|--------|------|---------|
-| `github.com/jokarl/tfclassify` | `.` | CLI and core packages |
-| `github.com/jokarl/tfclassify/sdk` | `sdk/` | Plugin authoring SDK (minimal dependencies) |
-| `github.com/jokarl/tfclassify-plugin-azurerm` | `plugins/azurerm/` | Example Azure deep inspection plugin |
 
 ## Development
 
 ```bash
-make build          # Build binary to bin/tfclassify
-make build-all      # Build CLI and azurerm plugin
-make test           # Run all tests across workspace
-make vet            # Run go vet
-make lint           # Run golangci-lint
-make generate-roles # Refresh Azure role database from AzAdvertizer
+make build          # Build CLI → bin/tfclassify
+make build-all      # Build CLI + azurerm plugin
+make test           # Run all tests across workspace (go test ./...)
+make vet            # Static analysis (go vet ./...)
+make lint           # golangci-lint run ./...
+make generate-roles # Refresh Azure role database from AzAdvertizer CSV
 make clean          # Remove build artifacts
 ```
 
-## Architecture decisions
+Run a single test:
+
+```bash
+go test ./pkg/classify/ -run TestClassifier_Deletion
+go test ./plugins/azurerm/ -run TestPrivilege
+```
+
+Before committing, run vulnerability check (enforced by CI):
+
+```bash
+govulncheck ./...
+```
+
+Protobuf code generation (output in `sdk/pb/`):
+
+```bash
+protoc --go_out=. --go-grpc_out=. proto/tfclassify.proto
+```
+
+## Architecture Decisions
 
 | ADR | Decision |
 |-----|----------|

--- a/docs/examples/full-reference/README.md
+++ b/docs/examples/full-reference/README.md
@@ -1,0 +1,94 @@
+# Full Reference
+
+A comprehensive configuration using every available field: multiple classification levels, rule descriptions, `not_resource` patterns, plugin configuration, and all `defaults` options. This example serves as an annotated reference for all `.tfclassify.hcl` capabilities.
+
+## Configuration
+
+See [`.tfclassify.hcl`](.tfclassify.hcl) for the fully annotated configuration file. Key features demonstrated:
+
+| Feature | Where |
+|---------|-------|
+| Plugin declaration (enabled + disabled) | `plugin "azurerm"`, `plugin "aws"` |
+| Plugin-specific config block | `config { privilege_enabled = true ... }` |
+| Multiple rules per classification | `classification "critical"` has 3 rules |
+| Rule descriptions | `description = "..."` on each rule block |
+| Action filtering | `actions = ["delete"]` on critical rules |
+| `not_resource` exclusion | `classification "standard"` uses `not_resource` |
+| Glob precision (`*_key_vault` vs `*_key_vault_*`) | Rules 2-3 in critical/high |
+| Five-level precedence with exit codes | `precedence = ["critical", "high", "standard", "low", "auto"]` |
+| `plugin_timeout` default | `defaults { plugin_timeout = "30s" }` |
+
+## Terraform Plan
+
+The plan includes seven resources across all five classification levels:
+
+| Resource | Type | Action | Expected Classification | Why |
+|----------|------|--------|------------------------|-----|
+| `azurerm_role_assignment.admin` | `azurerm_role_assignment` | delete | critical | Matches `*_role_*` with `actions = ["delete"]` |
+| `azurerm_subscription.production` | `azurerm_subscription` | update | critical | Matches `*_subscription*` (any action) |
+| `azurerm_network_security_rule.allow_ssh` | `azurerm_network_security_rule` | create | high | Matches `*_security_rule` |
+| `azurerm_key_vault_secret.db_password` | `azurerm_key_vault_secret` | create | high | Matches `*_key_vault_*` |
+| `azurerm_monitor_diagnostic_setting.logs` | `azurerm_monitor_diagnostic_setting` | create | low | Matches `*_diagnostic_*` |
+| `azurerm_virtual_network.main` | `azurerm_virtual_network` | create | standard | Matches `not_resource` rule (not monitoring/logging) |
+| `azurerm_resource_group.production` | `azurerm_resource_group` | no-op | auto | Matches `resource = ["*"]` with `actions = ["no-op"]` |
+
+## Running
+
+```bash
+tfclassify \
+  -p docs/examples/full-reference/plan.json \
+  -c docs/examples/full-reference/.tfclassify.hcl \
+  -v
+```
+
+## Expected Output
+
+```
+Classification: critical
+Exit code: 4
+Resources: 7
+
+[critical] (2 resources)
+  Requires security team approval — blocks automated deployment
+  - azurerm_role_assignment.admin (azurerm_role_assignment) [delete]
+    Rule: Deleting IAM or role resources requires security review (resource: *_role_*, ...)
+  - azurerm_subscription.production (azurerm_subscription) [update]
+    Rule: Subscription-level changes affect the entire tenant (resource: *_subscription*, ...)
+
+[high] (2 resources)
+  Requires team lead approval before merge
+  - azurerm_network_security_rule.allow_ssh (azurerm_network_security_rule) [create]
+    Rule: Network security changes affect access controls (resource: *_security_rule, ...)
+  - azurerm_key_vault_secret.db_password (azurerm_key_vault_secret) [create]
+    Rule: Key vault secret/key changes need review (resource: *_key_vault_*)
+
+[standard] (1 resources)
+  Standard change process — peer review required
+  - azurerm_virtual_network.main (azurerm_virtual_network) [create]
+    Rule: All infrastructure changes not covered above (not_resource: *_monitor_*, ...)
+
+[low] (1 resources)
+  Observability changes — auto-approved with notification
+  - azurerm_monitor_diagnostic_setting.logs (azurerm_monitor_diagnostic_setting) [create]
+    Rule: Monitoring and logging changes are low-risk (resource: *_monitor_*, ...)
+
+[auto] (1 resources)
+  No approval needed
+  - azurerm_resource_group.production (azurerm_resource_group) [no-op]
+    Rule: No actual changes detected (resource: *)
+```
+
+Exit code **4** corresponds to `critical` in a five-level precedence list (auto=0, low=1, standard=2, high=3, critical=4).
+
+## What This Demonstrates
+
+| Concept | Detail |
+|---------|--------|
+| Five precedence levels | `critical` → `high` → `standard` → `low` → `auto` with exit codes 4-0 |
+| Rule descriptions in output | Custom descriptions appear instead of auto-generated ones |
+| Glob precision | `*_key_vault` matches the vault itself; `*_key_vault_*` matches children only |
+| `not_resource` | Standard catches everything except monitoring resources |
+| `actions` filtering | Same resource type can be critical (delete) vs high (create/update) |
+| No-op classification | Resources with no changes classified as auto (exit code 0) |
+| Plugin configuration | Disabled plugins keep config for re-enabling later |
+| Sensitive attributes | `db_password` has `after_sensitive.value = true` (detected by builtin analyzer) |

--- a/docs/examples/full-reference/plan.json
+++ b/docs/examples/full-reference/plan.json
@@ -1,0 +1,163 @@
+{
+  "format_version": "1.2",
+  "terraform_version": "1.9.0",
+  "resource_changes": [
+    {
+      "address": "azurerm_role_assignment.admin",
+      "mode": "managed",
+      "type": "azurerm_role_assignment",
+      "name": "admin",
+      "provider_name": "registry.terraform.io/hashicorp/azurerm",
+      "change": {
+        "actions": ["delete"],
+        "before": {
+          "principal_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+          "role_definition_name": "Owner",
+          "scope": "/subscriptions/00000000-0000-0000-0000-000000000000"
+        },
+        "after": null,
+        "after_unknown": {},
+        "before_sensitive": false,
+        "after_sensitive": false
+      }
+    },
+    {
+      "address": "azurerm_subscription.production",
+      "mode": "managed",
+      "type": "azurerm_subscription",
+      "name": "production",
+      "provider_name": "registry.terraform.io/hashicorp/azurerm",
+      "change": {
+        "actions": ["update"],
+        "before": {
+          "subscription_name": "prod-old",
+          "subscription_id": "00000000-0000-0000-0000-000000000000"
+        },
+        "after": {
+          "subscription_name": "prod-new",
+          "subscription_id": "00000000-0000-0000-0000-000000000000"
+        },
+        "after_unknown": {},
+        "before_sensitive": false,
+        "after_sensitive": false
+      }
+    },
+    {
+      "address": "azurerm_network_security_rule.allow_ssh",
+      "mode": "managed",
+      "type": "azurerm_network_security_rule",
+      "name": "allow_ssh",
+      "provider_name": "registry.terraform.io/hashicorp/azurerm",
+      "change": {
+        "actions": ["create"],
+        "before": null,
+        "after": {
+          "name": "allow-ssh",
+          "priority": 100,
+          "direction": "Inbound",
+          "access": "Allow",
+          "protocol": "Tcp",
+          "source_port_range": "*",
+          "destination_port_range": "22",
+          "source_address_prefix": "*",
+          "destination_address_prefix": "*",
+          "resource_group_name": "rg-production",
+          "network_security_group_name": "nsg-production"
+        },
+        "after_unknown": {
+          "id": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": false
+      }
+    },
+    {
+      "address": "azurerm_key_vault_secret.db_password",
+      "mode": "managed",
+      "type": "azurerm_key_vault_secret",
+      "name": "db_password",
+      "provider_name": "registry.terraform.io/hashicorp/azurerm",
+      "change": {
+        "actions": ["create"],
+        "before": null,
+        "after": {
+          "name": "db-password",
+          "key_vault_id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-production/providers/Microsoft.KeyVault/vaults/kv-production",
+          "value": "s3cret"
+        },
+        "after_unknown": {
+          "id": true,
+          "version": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "value": true
+        }
+      }
+    },
+    {
+      "address": "azurerm_monitor_diagnostic_setting.logs",
+      "mode": "managed",
+      "type": "azurerm_monitor_diagnostic_setting",
+      "name": "logs",
+      "provider_name": "registry.terraform.io/hashicorp/azurerm",
+      "change": {
+        "actions": ["create"],
+        "before": null,
+        "after": {
+          "name": "send-to-log-analytics",
+          "target_resource_id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-production/providers/Microsoft.Compute/virtualMachines/vm-production",
+          "log_analytics_workspace_id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-monitoring/providers/Microsoft.OperationalInsights/workspaces/law-production"
+        },
+        "after_unknown": {
+          "id": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": false
+      }
+    },
+    {
+      "address": "azurerm_virtual_network.main",
+      "mode": "managed",
+      "type": "azurerm_virtual_network",
+      "name": "main",
+      "provider_name": "registry.terraform.io/hashicorp/azurerm",
+      "change": {
+        "actions": ["create"],
+        "before": null,
+        "after": {
+          "name": "vnet-production",
+          "address_space": ["10.0.0.0/16"],
+          "location": "westeurope",
+          "resource_group_name": "rg-production"
+        },
+        "after_unknown": {
+          "id": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": false
+      }
+    },
+    {
+      "address": "azurerm_resource_group.production",
+      "mode": "managed",
+      "type": "azurerm_resource_group",
+      "name": "production",
+      "provider_name": "registry.terraform.io/hashicorp/azurerm",
+      "change": {
+        "actions": ["no-op"],
+        "before": {
+          "name": "rg-production",
+          "location": "westeurope"
+        },
+        "after": {
+          "name": "rg-production",
+          "location": "westeurope"
+        },
+        "after_unknown": {},
+        "before_sensitive": false,
+        "after_sensitive": false
+      }
+    }
+  ]
+}

--- a/plugins/azurerm/README.md
+++ b/plugins/azurerm/README.md
@@ -1,0 +1,363 @@
+# tfclassify Azure Plugin
+
+Deep inspection plugin for Azure Resource Manager (azurerm) resources. Analyzes actual resource attribute values -- role permissions, network sources, key vault grants -- to produce graduated severity scores that go beyond what pattern matching can detect.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Analyzers](#analyzers)
+  - [Privilege Escalation](#privilege-escalation)
+  - [Network Exposure](#network-exposure)
+  - [Key Vault Access](#key-vault-access)
+- [Configuration](#configuration)
+  - [Enabling the Plugin](#enabling-the-plugin)
+  - [Plugin Config Options](#plugin-config-options)
+  - [Full Configuration Example](#full-configuration-example)
+- [How Scoring Works](#how-scoring-works)
+  - [Permission Tiers](#permission-tiers)
+  - [Scope Multipliers](#scope-multipliers)
+  - [Scoring Example](#scoring-example)
+- [Role Resolution](#role-resolution)
+- [Building](#building)
+- [Development](#development)
+
+## Overview
+
+The azurerm plugin provides three analyzers that inspect Azure-specific resource attributes:
+
+| Analyzer | Resource Type | Detects |
+|----------|--------------|---------|
+| `privilege-escalation` | `azurerm_role_assignment` | Role changes with permission-based severity scoring |
+| `network-exposure` | `azurerm_network_security_rule` | Inbound rules with overly permissive sources |
+| `key-vault-access` | `azurerm_key_vault_access_policy` | Access policies granting destructive permissions |
+
+Plugin decisions are merged with core classification rules via the host's precedence system. A plugin can escalate a resource's classification but never lower it.
+
+## Analyzers
+
+### Privilege Escalation
+
+Detects privilege escalation in Azure role assignments by computing a severity score from the role's actual permission set rather than relying on role name matching.
+
+**Resource pattern:** `azurerm_role_assignment`
+
+**What it detects:**
+- New privileged role assignments (e.g., assigning Owner to a principal)
+- Role escalations (e.g., changing Reader to Contributor)
+- Role de-escalations (e.g., removing Owner, always severity 40)
+
+**How it works:**
+1. Resolves the role being assigned (see [Role Resolution](#role-resolution))
+2. Scores the role's permissions using tiered analysis (see [Permission Tiers](#permission-tiers))
+3. Applies a scope multiplier based on the ARM scope path (see [Scope Multipliers](#scope-multipliers))
+4. Compares before/after scores to determine escalation direction
+
+**Example output:**
+
+```
+privileged role "Owner" assigned (severity: 95)
+role escalated from "Reader" to "Contributor" (severity: 70)
+role de-escalated from "Owner" to "Reader" (severity: 40)
+```
+
+### Network Exposure
+
+Detects overly permissive network security rules that allow inbound traffic from broad sources.
+
+**Resource pattern:** `azurerm_network_security_rule`
+
+**What it detects:**
+- Inbound allow rules where `source_address_prefix` is `*`, `0.0.0.0/0`, or `Internet`
+- Also checks `source_address_prefixes` (the array variant)
+
+**Severity:** 85 (fixed)
+
+**Conditions (all must be true):**
+- `direction` is `Inbound`
+- `access` is `Allow`
+- Source matches one of the configured permissive sources
+
+### Key Vault Access
+
+Detects when key vault access policies grant destructive permissions.
+
+**Resource pattern:** `azurerm_key_vault_access_policy`
+
+**What it detects:**
+- `delete` or `purge` in any of these permission fields:
+  - `secret_permissions`
+  - `key_permissions`
+  - `certificate_permissions`
+  - `storage_permissions`
+
+**Severity:** 80 (fixed)
+
+## Configuration
+
+### Enabling the Plugin
+
+Add a `plugin` block to `.tfclassify.hcl`:
+
+```hcl
+# For local development (binary in plugin search path):
+plugin "azurerm" {
+  enabled = true
+}
+
+# For distributed installation via tfclassify init:
+plugin "azurerm" {
+  enabled = true
+  source  = "github.com/jokarl/tfclassify"
+  version = "0.1.0"
+}
+```
+
+Then install:
+
+```bash
+tfclassify init
+```
+
+### Plugin Config Options
+
+All options are set inside the `config {}` block of the plugin declaration. Every option has a sensible default -- you only need to specify values you want to override.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `privilege_enabled` | bool | `true` | Enable the privilege escalation analyzer |
+| `network_enabled` | bool | `true` | Enable the network exposure analyzer |
+| `keyvault_enabled` | bool | `true` | Enable the key vault access analyzer |
+
+The following options are available programmatically via `PluginConfig` but are not currently exposed through HCL config:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `PrivilegedRoles` | `[]string` | `["Owner", "User Access Administrator", "Contributor"]` | Fallback roles when not found in the built-in database |
+| `PermissiveSources` | `[]string` | `["*", "0.0.0.0/0", "Internet"]` | Network sources that trigger network exposure detection |
+| `DestructiveKVPermissions` | `[]string` | `["delete", "purge"]` | Key vault permissions considered destructive |
+| `UnknownPrivilegedSeverity` | `int` | `80` | Severity for roles in PrivilegedRoles but not in the database |
+| `UnknownRoleSeverity` | `int` | `50` | Severity for completely unknown roles |
+| `CrossReferenceCustomRoles` | `bool` | `true` | Look up `azurerm_role_definition` resources in the plan for custom role scoring |
+
+### Full Configuration Example
+
+A `.tfclassify.hcl` that uses the azurerm plugin alongside core classification rules:
+
+```hcl
+# ─── Plugin ──────────────────────────────────────────────────────────
+plugin "azurerm" {
+  enabled = true
+  source  = "github.com/jokarl/tfclassify"
+  version = "0.1.0"
+
+  config {
+    privilege_enabled = true
+    network_enabled   = true
+    keyvault_enabled  = true
+  }
+}
+
+# ─── Classifications ─────────────────────────────────────────────────
+#
+# Core rules handle the broad patterns.
+# The azurerm plugin adds deep inspection on top -- its decisions
+# merge via precedence and can escalate but never lower a classification.
+
+classification "critical" {
+  description = "Requires security team approval"
+
+  rule {
+    description = "Deleting IAM or role resources"
+    resource    = ["*_role_*", "*_iam_*"]
+    actions     = ["delete"]
+  }
+
+  rule {
+    description = "Deleting a key vault destroys all secrets"
+    resource    = ["*_key_vault"]
+    actions     = ["delete"]
+  }
+}
+
+classification "high" {
+  description = "Requires team lead approval"
+
+  rule {
+    description = "Non-destructive IAM changes"
+    resource    = ["*_role_*", "*_iam_*"]
+    actions     = ["create", "update"]
+  }
+
+  rule {
+    description = "Network security changes"
+    resource    = ["*_security_rule", "*_firewall_*"]
+  }
+
+  rule {
+    description = "Key vault secret/key changes"
+    resource    = ["*_key_vault_*"]
+  }
+}
+
+classification "standard" {
+  description = "Standard change process"
+
+  rule {
+    resource = ["*"]
+  }
+}
+
+classification "auto" {
+  description = "No approval needed"
+
+  rule {
+    resource = ["*"]
+    actions  = ["no-op"]
+  }
+}
+
+# With the azurerm plugin enabled, a simple role assignment create
+# that core rules classify as "high" may be escalated to "critical"
+# if the plugin detects a high-severity permission set (e.g., Owner).
+precedence = ["critical", "high", "standard", "auto"]
+
+defaults {
+  unclassified   = "standard"
+  no_changes     = "auto"
+  plugin_timeout = "30s"
+}
+```
+
+## How Scoring Works
+
+The privilege escalation analyzer uses a multi-factor scoring system to compute graduated severity for role assignments.
+
+### Permission Tiers
+
+Roles are scored based on their effective permission set (actions minus notActions):
+
+| Tier | Score | Pattern | Example Roles |
+|------|-------|---------|---------------|
+| 1 | 95 | Unrestricted wildcard `*` without auth exclusion | Owner |
+| 2 | 85 | `Microsoft.Authorization/*` control | User Access Administrator |
+| 3 | 75 | Targeted `Microsoft.Authorization/roleAssignments/write` | Custom roles with role assignment write |
+| 4 | 70 | Wildcard `*` with `Microsoft.Authorization` excluded | Contributor |
+| 5 | 50-65 | Provider wildcards (`Microsoft.Compute/*`, etc.) | Custom roles with broad provider access |
+| 6 | 30 | Limited write access | Custom roles with specific write actions |
+| 7 | 15 | Read-only access | Reader, custom read-only roles |
+| 8 | 0 | No permissions | No actions defined |
+
+### Scope Multipliers
+
+After computing a base score, a multiplier is applied based on the ARM scope path of the role assignment:
+
+| Scope Level | Multiplier | Detection |
+|-------------|------------|-----------|
+| Management Group | 1.1x | Path contains `microsoft.management/managementgroups` |
+| Subscription | 1.0x | Path starts with `/subscriptions/` with no resource group |
+| Resource Group | 0.8x | Path contains `/resourceGroups/` with no `/providers/` after |
+| Resource | 0.6x | Path contains `/providers/` after resource group |
+| Unknown | 0.9x | Unrecognized scope format |
+
+The final score is clamped to [0, 100].
+
+### Scoring Example
+
+Assigning the **Contributor** role at **subscription** scope:
+
+1. Contributor has `Actions: ["*"]`, `NotActions: ["Microsoft.Authorization/*/Write", ...]`
+2. Tier 4 match: wildcard with auth excluded → base score **70**
+3. Subscription scope → multiplier **1.0**
+4. Final severity: **70**
+
+Assigning the **Owner** role at **resource group** scope:
+
+1. Owner has `Actions: ["*"]`, `NotActions: []`
+2. Tier 1 match: unrestricted wildcard → base score **95**
+3. Resource group scope → multiplier **0.8**
+4. Final severity: **76** (95 * 0.8, rounded)
+
+## Role Resolution
+
+The privilege escalation analyzer resolves roles through a four-level fallback chain:
+
+1. **Built-in database**: Embedded JSON database of 400+ Azure built-in roles with full permission sets. Roles are looked up by `role_definition_name` or `role_definition_id`. This is the primary source.
+
+2. **Custom roles from plan**: If `CrossReferenceCustomRoles` is enabled (default), the analyzer queries the plan for `azurerm_role_definition` resources and scores their permission sets.
+
+3. **Config fallback**: If the role name appears in `PrivilegedRoles` but is not in the database or plan, it gets `UnknownPrivilegedSeverity` (default 80).
+
+4. **Unknown**: Roles not found through any mechanism get `UnknownRoleSeverity` (default 50).
+
+Decision metadata includes a `role_source` field indicating which resolution path was used: `builtin`, `plan-custom-role`, `config-fallback`, or `unknown`.
+
+## Building
+
+From the repository root:
+
+```bash
+# Build the plugin binary
+go build -o bin/tfclassify-plugin-azurerm ./plugins/azurerm
+
+# Or use the Makefile
+make build-all
+```
+
+For local testing, copy the binary to a plugin search path:
+
+```bash
+mkdir -p .tfclassify/plugins
+cp bin/tfclassify-plugin-azurerm .tfclassify/plugins/
+```
+
+## Development
+
+### Running Tests
+
+```bash
+# All plugin tests
+go test ./plugins/azurerm/...
+
+# Specific test
+go test ./plugins/azurerm/ -run TestPrivilege
+go test ./plugins/azurerm/ -run TestNetwork
+go test ./plugins/azurerm/ -run TestKeyVault
+go test ./plugins/azurerm/ -run TestScoring
+go test ./plugins/azurerm/ -run TestScope
+```
+
+### Refreshing the Role Database
+
+The embedded role database is generated from the [AzAdvertizer](https://www.azadvertizer.net/) CSV:
+
+```bash
+make generate-roles
+```
+
+This downloads the latest CSV and converts it to `plugins/azurerm/roledata/roles.json` using the `tools/csv2roles/` tool.
+
+### Module Structure
+
+```
+plugins/azurerm/
+├── main.go              # Entry point: calls sdk/plugin.Serve()
+├── plugin.go            # AzurermPluginSet and PluginConfig
+├── privilege.go         # PrivilegeEscalationAnalyzer
+├── network.go           # NetworkExposureAnalyzer
+├── keyvault.go          # KeyVaultAccessAnalyzer
+├── scoring.go           # Permission-based risk scoring
+├── scope.go             # ARM scope path parsing and multipliers
+├── roles.go             # RoleDatabase (embedded JSON, lookup by name/ID)
+├── helpers.go           # Shared utility functions
+├── roledata/
+│   └── roles.json       # Embedded Azure built-in role definitions
+├── *_test.go            # Tests for each component
+├── go.mod               # Module: github.com/jokarl/tfclassify-plugin-azurerm
+└── CHANGELOG.md
+```
+
+The module depends only on the tfclassify SDK (`github.com/jokarl/tfclassify/sdk`). During development, a `replace` directive in `go.mod` resolves the SDK locally:
+
+```
+replace github.com/jokarl/tfclassify/sdk => ../../sdk
+```

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,0 +1,547 @@
+# tfclassify Plugin SDK
+
+The Plugin SDK provides the public interfaces and types for building tfclassify deep inspection plugins. It is a standalone Go module with minimal dependencies (go-plugin, gRPC, protobuf), keeping plugin binaries lightweight.
+
+```
+go get github.com/jokarl/tfclassify/sdk
+```
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Architecture](#architecture)
+- [Interfaces](#interfaces)
+  - [Analyzer](#analyzer)
+  - [Runner](#runner)
+  - [PluginSet](#pluginset)
+- [Types](#types)
+  - [ResourceChange](#resourcechange)
+  - [Decision](#decision)
+  - [ConfigSchemaSpec](#configschemaspec)
+- [Helper Structs](#helper-structs)
+  - [BuiltinPluginSet](#builtinpluginset)
+  - [DefaultAnalyzer](#defaultanalyzer)
+- [Writing a Plugin](#writing-a-plugin)
+  - [1. Create the Module](#1-create-the-module)
+  - [2. Define the Entry Point](#2-define-the-entry-point)
+  - [3. Define the PluginSet](#3-define-the-pluginset)
+  - [4. Implement an Analyzer](#4-implement-an-analyzer)
+  - [5. Emit Decisions](#5-emit-decisions)
+  - [6. Build and Install](#6-build-and-install)
+- [Inspecting Resource Attributes](#inspecting-resource-attributes)
+- [Testing](#testing)
+- [Severity Guidelines](#severity-guidelines)
+- [gRPC Protocol](#grpc-protocol)
+- [Version Compatibility](#version-compatibility)
+
+## Overview
+
+tfclassify uses a three-layer classification model:
+
+| Layer | Mechanism | Runs |
+|-------|-----------|------|
+| 1. Core rules | Config-driven glob pattern matching | In host process |
+| 2. Builtin analyzers | Cross-provider heuristics (deletion, replace, sensitive) | In host process |
+| 3. Deep inspection plugins | Provider-specific attribute analysis | Separate process via gRPC |
+
+This SDK is for **Layer 3** -- building plugins that inspect the actual values of resource attributes (role names, CIDR ranges, permission grants, etc.) rather than just matching on resource type and action.
+
+## Architecture
+
+Plugins run as separate processes. The host and plugin communicate bidirectionally over gRPC using [hashicorp/go-plugin](https://github.com/hashicorp/go-plugin):
+
+```
+┌─────────────────────┐          gRPC           ┌──────────────────────┐
+│     tfclassify      │ ───────────────────────▶ │       Plugin         │
+│       (host)        │                          │     (subprocess)     │
+│                     │  PluginService.Analyze() │                      │
+│                     │ ◀─────────────────────── │  Analyzer.Analyze()  │
+│  RunnerService      │  RunnerService calls:    │                      │
+│  (serves plan data) │  - GetResourceChanges()  │  runner.EmitDecision │
+│                     │  - GetResourceChange()   │                      │
+│                     │  - EmitDecision()        │                      │
+└─────────────────────┘                          └──────────────────────┘
+```
+
+1. Host starts the plugin binary as a subprocess
+2. go-plugin handshake and gRPC broker established
+3. Host calls `PluginService.Analyze()` with a broker ID
+4. Plugin uses the broker ID to dial back and create a `RunnerService` client
+5. Plugin queries plan data via `GetResourceChanges` / `GetResourceChange`
+6. Plugin reports findings via `EmitDecision`
+7. Host aggregates plugin decisions with core rule results
+
+## Interfaces
+
+### Analyzer
+
+The core interface every analyzer must implement. Each analyzer inspects a subset of resource changes and emits classification decisions.
+
+```go
+type Analyzer interface {
+    // Name returns the unique name within the plugin set.
+    Name() string
+
+    // Enabled returns whether this analyzer should run.
+    Enabled() bool
+
+    // ResourcePatterns returns glob patterns for resources this analyzer
+    // inspects. Return nil or empty to receive all resources.
+    ResourcePatterns() []string
+
+    // Analyze inspects resources and emits decisions via the Runner.
+    Analyze(runner Runner) error
+}
+```
+
+Embed `DefaultAnalyzer` to get default implementations for `Enabled()` (returns `true`) and `ResourcePatterns()` (returns `nil`).
+
+### Runner
+
+The host-provided interface that plugins call during analysis to query plan data and emit decisions. You do not implement this -- it is passed to your `Analyze()` method.
+
+```go
+type Runner interface {
+    // GetResourceChanges returns resources matching glob patterns.
+    // Empty patterns returns all resources.
+    GetResourceChanges(patterns []string) ([]*ResourceChange, error)
+
+    // GetResourceChange returns a single resource by address.
+    GetResourceChange(address string) (*ResourceChange, error)
+
+    // EmitDecision records a classification decision for a resource.
+    EmitDecision(analyzer Analyzer, change *ResourceChange, decision *Decision) error
+}
+```
+
+### PluginSet
+
+Defines a collection of analyzers provided by a single plugin binary.
+
+```go
+type PluginSet interface {
+    PluginSetName() string
+    PluginSetVersion() string
+    AnalyzerNames() []string
+    VersionConstraint() string        // semver constraint on host, e.g. ">= 0.1.0"
+    ConfigSchema() *ConfigSchemaSpec  // nil if no validation needed
+}
+```
+
+Use `BuiltinPluginSet` instead of implementing this directly.
+
+## Types
+
+### ResourceChange
+
+Represents a single resource change from a Terraform plan:
+
+```go
+type ResourceChange struct {
+    Address         string                 // "azurerm_role_assignment.admin"
+    Type            string                 // "azurerm_role_assignment"
+    ProviderName    string                 // "registry.terraform.io/hashicorp/azurerm"
+    Mode            string                 // "managed" or "data"
+    Actions         []string               // ["create"], ["update"], ["delete", "create"]
+    Before          map[string]interface{} // State before change (nil for creates)
+    After           map[string]interface{} // State after change (nil for deletes)
+    BeforeSensitive interface{}            // Sensitive attribute markers (before)
+    AfterSensitive  interface{}            // Sensitive attribute markers (after)
+}
+```
+
+`Before` and `After` are JSON-decoded maps of the resource's attributes. For creates, `Before` is nil. For deletes, `After` is nil. For replacements (destroy-and-recreate), `Actions` contains `["delete", "create"]`.
+
+### Decision
+
+A classification finding emitted by an analyzer:
+
+```go
+type Decision struct {
+    // Classification level to assign. Leave empty to let the host
+    // use severity to determine classification.
+    Classification string
+
+    // Human-readable explanation of why this decision was made.
+    Reason string
+
+    // Fine-grained risk score (0-100). Higher = more severe.
+    Severity int
+
+    // Additional context (optional). Included in JSON output.
+    Metadata map[string]interface{}
+}
+```
+
+### ConfigSchemaSpec
+
+Describes the expected structure of a plugin's `config {}` block for validation:
+
+```go
+type ConfigSchemaSpec struct {
+    Attributes []ConfigAttribute
+}
+
+type ConfigAttribute struct {
+    Name        string // Attribute name
+    Type        string // HCL type: "string", "number", "bool", "list(string)", etc.
+    Required    bool
+    Description string
+}
+```
+
+## Helper Structs
+
+### BuiltinPluginSet
+
+A ready-made `PluginSet` implementation. Embed it and set the fields:
+
+```go
+type BuiltinPluginSet struct {
+    Name                  string
+    Version               string
+    Analyzers             []Analyzer
+    HostVersionConstraint string            // Optional semver constraint
+    Schema                *ConfigSchemaSpec // Optional config validation
+}
+```
+
+Provides `PluginSetName()`, `PluginSetVersion()`, `AnalyzerNames()`, `VersionConstraint()`, `ConfigSchema()`, and a helper `GetAnalyzer(name string) Analyzer`.
+
+### DefaultAnalyzer
+
+Embed in your analyzer structs to get default implementations:
+
+```go
+type DefaultAnalyzer struct{}
+
+func (d DefaultAnalyzer) Enabled() bool          { return true }
+func (d DefaultAnalyzer) ResourcePatterns() []string { return nil }
+```
+
+Override `Enabled()` to support toggling analyzers via configuration. Override `ResourcePatterns()` to restrict which resources your analyzer receives.
+
+## Writing a Plugin
+
+### 1. Create the Module
+
+```bash
+mkdir tfclassify-plugin-aws-securitygroups
+cd tfclassify-plugin-aws-securitygroups
+go mod init github.com/yourorg/tfclassify-plugin-aws-securitygroups
+go get github.com/jokarl/tfclassify/sdk
+```
+
+### 2. Define the Entry Point
+
+`main.go` -- calls `plugin.Serve()` with your `PluginSet`:
+
+```go
+package main
+
+import (
+    sdkplugin "github.com/jokarl/tfclassify/sdk/plugin"
+)
+
+func main() {
+    sdkplugin.Serve(&sdkplugin.ServeOpts{
+        PluginSet: NewSecurityGroupPluginSet(),
+    })
+}
+```
+
+### 3. Define the PluginSet
+
+`plugin.go` -- group your analyzers together:
+
+```go
+package main
+
+import "github.com/jokarl/tfclassify/sdk"
+
+const Version = "0.1.0"
+
+type SecurityGroupPluginSet struct {
+    *sdk.BuiltinPluginSet
+}
+
+func NewSecurityGroupPluginSet() *SecurityGroupPluginSet {
+    ps := &SecurityGroupPluginSet{}
+    ps.BuiltinPluginSet = &sdk.BuiltinPluginSet{
+        Name:    "aws-securitygroups",
+        Version: Version,
+        Analyzers: []sdk.Analyzer{
+            NewOpenIngressAnalyzer(),
+        },
+    }
+    return ps
+}
+```
+
+### 4. Implement an Analyzer
+
+`open_ingress.go` -- detect security groups allowing traffic from 0.0.0.0/0:
+
+```go
+package main
+
+import (
+    "fmt"
+    "github.com/jokarl/tfclassify/sdk"
+)
+
+type OpenIngressAnalyzer struct {
+    sdk.DefaultAnalyzer
+}
+
+func NewOpenIngressAnalyzer() *OpenIngressAnalyzer {
+    return &OpenIngressAnalyzer{}
+}
+
+func (a *OpenIngressAnalyzer) Name() string {
+    return "open-ingress"
+}
+
+func (a *OpenIngressAnalyzer) ResourcePatterns() []string {
+    return []string{"aws_security_group_rule"}
+}
+
+func (a *OpenIngressAnalyzer) Analyze(runner sdk.Runner) error {
+    changes, err := runner.GetResourceChanges(a.ResourcePatterns())
+    if err != nil {
+        return fmt.Errorf("failed to get resource changes: %w", err)
+    }
+
+    for _, change := range changes {
+        after := change.After
+        if after == nil {
+            continue // Being deleted
+        }
+
+        ruleType, _ := after["type"].(string)
+        cidr, _ := after["cidr_blocks"].([]interface{})
+
+        if ruleType != "ingress" {
+            continue
+        }
+
+        for _, block := range cidr {
+            if s, ok := block.(string); ok && s == "0.0.0.0/0" {
+                decision := &sdk.Decision{
+                    Reason:   fmt.Sprintf("security group rule allows ingress from %s", s),
+                    Severity: 85,
+                    Metadata: map[string]interface{}{
+                        "analyzer":    "open-ingress",
+                        "cidr_block":  s,
+                    },
+                }
+                if err := runner.EmitDecision(a, change, decision); err != nil {
+                    return fmt.Errorf("failed to emit decision: %w", err)
+                }
+            }
+        }
+    }
+    return nil
+}
+```
+
+### 5. Emit Decisions
+
+Call `runner.EmitDecision()` for each finding. Key fields:
+
+| Field | Usage |
+|-------|-------|
+| `Classification` | Leave empty (recommended) -- the host maps severity to classifications via precedence. Set explicitly only if you need to force a specific level. |
+| `Reason` | Human-readable explanation shown in output. |
+| `Severity` | 0-100 risk score. Used for ordering and classification mapping. |
+| `Metadata` | Arbitrary key-value pairs included in JSON output. |
+
+### 6. Build and Install
+
+```bash
+# Build
+go build -o tfclassify-plugin-aws-securitygroups .
+
+# Install locally
+mkdir -p .tfclassify/plugins
+cp tfclassify-plugin-aws-securitygroups .tfclassify/plugins/
+
+# Or install to home directory
+mkdir -p ~/.tfclassify/plugins
+cp tfclassify-plugin-aws-securitygroups ~/.tfclassify/plugins/
+```
+
+Configure in `.tfclassify.hcl`:
+
+```hcl
+plugin "aws-securitygroups" {
+  enabled = true
+  # For local development, omit source/version.
+  # The host discovers the binary from the plugin directories.
+}
+```
+
+For distribution via GitHub releases, add `source` and `version` so users can run `tfclassify init`:
+
+```hcl
+plugin "aws-securitygroups" {
+  enabled = true
+  source  = "github.com/yourorg/tfclassify-plugin-aws-securitygroups"
+  version = "0.1.0"
+}
+```
+
+## Inspecting Resource Attributes
+
+Resource attributes arrive as `map[string]interface{}` from JSON decoding. Always use safe type assertions:
+
+```go
+// String field
+if name, ok := change.After["name"].(string); ok {
+    // use name
+}
+
+// Nested object
+if osDisk, ok := change.After["os_disk"].(map[string]interface{}); ok {
+    if caching, ok := osDisk["caching"].(string); ok {
+        // use caching
+    }
+}
+
+// List field
+if permissions, ok := change.After["secret_permissions"].([]interface{}); ok {
+    for _, p := range permissions {
+        if perm, ok := p.(string); ok {
+            // use perm
+        }
+    }
+}
+
+// Numeric field (JSON numbers decode as float64)
+if count, ok := change.After["count"].(float64); ok {
+    intCount := int(count)
+    // use intCount
+}
+```
+
+A common pattern for safe string access:
+
+```go
+func stringField(m map[string]interface{}, key string) string {
+    if m == nil {
+        return ""
+    }
+    if v, ok := m[key].(string); ok {
+        return v
+    }
+    return ""
+}
+```
+
+## Testing
+
+Create a mock `Runner` for unit tests:
+
+```go
+type mockRunner struct {
+    changes   []*sdk.ResourceChange
+    decisions []*capturedDecision
+}
+
+type capturedDecision struct {
+    analyzer string
+    address  string
+    decision *sdk.Decision
+}
+
+func (r *mockRunner) GetResourceChanges(patterns []string) ([]*sdk.ResourceChange, error) {
+    return r.changes, nil
+}
+
+func (r *mockRunner) GetResourceChange(address string) (*sdk.ResourceChange, error) {
+    for _, c := range r.changes {
+        if c.Address == address {
+            return c, nil
+        }
+    }
+    return nil, fmt.Errorf("not found: %s", address)
+}
+
+func (r *mockRunner) EmitDecision(analyzer sdk.Analyzer, change *sdk.ResourceChange, decision *sdk.Decision) error {
+    r.decisions = append(r.decisions, &capturedDecision{
+        analyzer: analyzer.Name(),
+        address:  change.Address,
+        decision: decision,
+    })
+    return nil
+}
+```
+
+Example test:
+
+```go
+func TestOpenIngress_DetectsWildcardCIDR(t *testing.T) {
+    analyzer := NewOpenIngressAnalyzer()
+
+    runner := &mockRunner{
+        changes: []*sdk.ResourceChange{
+            {
+                Address: "aws_security_group_rule.allow_all",
+                Type:    "aws_security_group_rule",
+                Actions: []string{"create"},
+                After: map[string]interface{}{
+                    "type":        "ingress",
+                    "cidr_blocks": []interface{}{"0.0.0.0/0"},
+                    "from_port":   float64(0),
+                    "to_port":     float64(65535),
+                },
+            },
+        },
+    }
+
+    if err := analyzer.Analyze(runner); err != nil {
+        t.Fatalf("unexpected error: %v", err)
+    }
+
+    if len(runner.decisions) != 1 {
+        t.Fatalf("expected 1 decision, got %d", len(runner.decisions))
+    }
+    if runner.decisions[0].decision.Severity != 85 {
+        t.Errorf("expected severity 85, got %d", runner.decisions[0].decision.Severity)
+    }
+}
+```
+
+## Severity Guidelines
+
+| Range | Use Case | Examples |
+|-------|----------|----------|
+| 90-100 | Critical security issues | Unrestricted wildcard permissions, Owner role assignment |
+| 80-89 | High-risk changes | Destructive KV permissions, open network rules |
+| 60-79 | Moderate concerns | Targeted auth write, broad provider wildcards |
+| 40-59 | Low-priority findings | De-escalation, limited write access |
+| 0-39 | Informational | Read-only changes, metadata updates |
+
+## gRPC Protocol
+
+Defined in [`proto/tfclassify.proto`](../proto/tfclassify.proto). Two services:
+
+**PluginService** (host calls plugin):
+- `GetPluginInfo` -- version negotiation
+- `GetConfigSchema` -- schema for config validation
+- `ApplyConfig` -- forward plugin-specific HCL config
+- `Analyze` -- start analysis (passes broker ID for callback)
+
+**RunnerService** (plugin calls host):
+- `GetResourceChanges` -- query resources by glob patterns
+- `GetResourceChange` -- query a single resource by address
+- `EmitDecision` -- record a classification decision
+
+Generated Go code lives in `sdk/pb/`. Plugin authors do not interact with the protobuf types directly -- the SDK handles serialization.
+
+## Version Compatibility
+
+- **`SDKVersion`** (currently `0.0.1`): embedded in every plugin binary and reported to the host during handshake. The host checks this against its supported SDK version constraints.
+- **`HostVersionConstraint`**: an optional semver constraint your plugin can set (e.g. `">= 0.1.0"`) to require a minimum host version. Set via `BuiltinPluginSet.HostVersionConstraint`.
+
+Both are checked during the go-plugin handshake. If either fails, the host logs the mismatch and skips the plugin.


### PR DESCRIPTION
- Add sdk/README.md with full interface docs, plugin authoring guide, and runnable examples
- Add plugins/azurerm/README.md covering analyzers, scoring tiers, scope multipliers, and configuration
- Complete the full-reference example with plan.json and README.md
- Restructure root README with ToC, cross-links to sub-project docs, and expanded sections
  (output formats, init command, glob pattern reference, three-layer model explanation)

https://claude.ai/code/session_0186T4HHdvGpmSFU7dmbnDMS