### PR TITLE
ci: nightly verification workflow and e2e test fixtures

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,208 @@
+name: Verify
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  id-token: write
+  contents: read
+  issues: write
+
+env:
+  ARM_CLIENT_ID: "415fa556-f0eb-4ed0-8eb0-9d7b66944996"
+  ARM_SUBSCRIPTION_ID: "0a271008-02cf-4a50-9bb3-afc7c4aed74c"
+  ARM_TENANT_ID: "9fc151d1-62b8-402f-b07e-91533ff07e0d"
+  ARM_USE_OIDC: "true"
+  TFCLASSIFY_PLUGIN_DIR: /tmp/tfclassify-plugins
+  RESOURCE_GROUP: rg-lab-johan.karlsson
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ env.ARM_CLIENT_ID }}
+          tenant-id: ${{ env.ARM_TENANT_ID }}
+          subscription-id: ${{ env.ARM_SUBSCRIPTION_ID }}
+
+      - name: Delete all resources in lab resource group
+        run: |
+          RG="${{ env.RESOURCE_GROUP }}"
+
+          # Remove role assignments first (scoped resources, not listed by az resource list)
+          echo "Removing role assignments..."
+          ASSIGNMENTS=$(az role assignment list --resource-group "$RG" --query "[].id" -o tsv)
+          if [ -n "$ASSIGNMENTS" ]; then
+            echo "$ASSIGNMENTS" | while read -r id; do
+              echo "  Deleting role assignment: $id"
+              az role assignment delete --ids "$id" || true
+            done
+          fi
+
+          # Delete remaining resources with retry passes to handle dependency ordering
+          for pass in 1 2 3; do
+            RESOURCE_IDS=$(az resource list --resource-group "$RG" --query "[].id" -o tsv)
+            if [ -z "$RESOURCE_IDS" ]; then
+              echo "Resource group is clean."
+              break
+            fi
+            echo "Cleanup pass $pass..."
+            echo "$RESOURCE_IDS" | while read -r id; do
+              echo "  Deleting: $id"
+              az resource delete --ids "$id" 2>/dev/null || true
+            done
+            [ "$pass" -lt 3 ] && sleep 15
+          done
+
+  verify:
+    needs: cleanup
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        use-case:
+          - role-assignment-privileged
+          - nsg-open-inbound
+          - route-table
+          - role-assignment-reader
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
+      - name: Download tfclassify
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Download latest CLI release
+          LATEST_CLI_TAG=$(gh release list --json tagName --jq \
+            '[.[] | select(.tagName | startswith("tfclassify-v"))][0].tagName')
+          gh release download "$LATEST_CLI_TAG" --pattern 'tfclassify_*_linux_amd64.zip'
+          unzip -o tfclassify_*.zip -d /usr/local/bin
+          chmod +x /usr/local/bin/tfclassify
+          rm -f tfclassify_*.zip
+
+          # Download latest plugin release
+          LATEST_PLUGIN_TAG=$(gh release list --json tagName --jq \
+            '[.[] | select(.tagName | startswith("tfclassify-plugin-azurerm-v"))][0].tagName')
+          gh release download "$LATEST_PLUGIN_TAG" --pattern 'tfclassify-plugin-azurerm_*_linux_amd64.zip'
+          mkdir -p "$TFCLASSIFY_PLUGIN_DIR"
+          unzip -o tfclassify-plugin-azurerm_*.zip -d "$TFCLASSIFY_PLUGIN_DIR"
+          chmod +x "$TFCLASSIFY_PLUGIN_DIR/tfclassify-plugin-azurerm"
+          rm -f tfclassify-plugin-azurerm_*.zip
+
+      - name: Record versions
+        id: versions
+        run: |
+          echo "tfclassify=$(tfclassify --version)" >> "$GITHUB_OUTPUT"
+          echo "terraform=$(terraform --version -json | jq -r .terraform_version)" >> "$GITHUB_OUTPUT"
+
+      - name: Terraform init
+        run: terraform -chdir=testdata/e2e/${{ matrix.use-case }} init
+
+      - name: Create plan
+        run: |
+          terraform -chdir=testdata/e2e/${{ matrix.use-case }} plan -out=create.tfplan
+          terraform -chdir=testdata/e2e/${{ matrix.use-case }} show -json create.tfplan \
+            > testdata/e2e/${{ matrix.use-case }}/create.json
+          echo "::group::Create plan JSON"
+          jq . testdata/e2e/${{ matrix.use-case }}/create.json
+          echo "::endgroup::"
+
+      - name: Classify create plan
+        id: classify-create
+        run: |
+          EXPECTED_EXIT=$(jq -r '.create.exit_code' testdata/e2e/${{ matrix.use-case }}/expected.json)
+          set +e
+          tfclassify \
+            -p testdata/e2e/${{ matrix.use-case }}/create.json \
+            -c testdata/e2e/${{ matrix.use-case }}/.tfclassify.hcl \
+            -o json > testdata/e2e/${{ matrix.use-case }}/create-result.json
+          ACTUAL_EXIT=$?
+          set -e
+          echo "::group::Classification result"
+          jq . testdata/e2e/${{ matrix.use-case }}/create-result.json
+          echo "::endgroup::"
+          echo "expected=$EXPECTED_EXIT" >> "$GITHUB_OUTPUT"
+          echo "actual=$ACTUAL_EXIT" >> "$GITHUB_OUTPUT"
+          if [ "$ACTUAL_EXIT" != "$EXPECTED_EXIT" ]; then
+            echo "::error::Create phase: expected exit code $EXPECTED_EXIT, got $ACTUAL_EXIT"
+            exit 1
+          fi
+
+      - name: Apply
+        id: apply
+        run: terraform -chdir=testdata/e2e/${{ matrix.use-case }} apply -auto-approve create.tfplan
+
+      - name: Destroy plan
+        run: |
+          terraform -chdir=testdata/e2e/${{ matrix.use-case }} plan -destroy -out=destroy.tfplan
+          terraform -chdir=testdata/e2e/${{ matrix.use-case }} show -json destroy.tfplan \
+            > testdata/e2e/${{ matrix.use-case }}/destroy.json
+          echo "::group::Destroy plan JSON"
+          jq . testdata/e2e/${{ matrix.use-case }}/destroy.json
+          echo "::endgroup::"
+
+      - name: Classify destroy plan
+        id: classify-destroy
+        run: |
+          EXPECTED_EXIT=$(jq -r '.destroy.exit_code' testdata/e2e/${{ matrix.use-case }}/expected.json)
+          set +e
+          tfclassify \
+            -p testdata/e2e/${{ matrix.use-case }}/destroy.json \
+            -c testdata/e2e/${{ matrix.use-case }}/.tfclassify.hcl \
+            -o json > testdata/e2e/${{ matrix.use-case }}/destroy-result.json
+          ACTUAL_EXIT=$?
+          set -e
+          echo "::group::Classification result"
+          jq . testdata/e2e/${{ matrix.use-case }}/destroy-result.json
+          echo "::endgroup::"
+          echo "expected=$EXPECTED_EXIT" >> "$GITHUB_OUTPUT"
+          echo "actual=$ACTUAL_EXIT" >> "$GITHUB_OUTPUT"
+          if [ "$ACTUAL_EXIT" != "$EXPECTED_EXIT" ]; then
+            echo "::error::Destroy phase: expected exit code $EXPECTED_EXIT, got $ACTUAL_EXIT"
+            exit 1
+          fi
+
+      - name: Cleanup
+        if: always() && steps.apply.outcome != 'skipped'
+        run: terraform -chdir=testdata/e2e/${{ matrix.use-case }} destroy -auto-approve
+
+      - name: Open issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create verification --color "d93f0b" \
+            --description "Nightly verification failure" --force 2>/dev/null || true
+
+          cat > /tmp/issue-body.md <<EOF
+          ## Verification failure: ${{ matrix.use-case }}
+
+          **Workflow run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+          ### Versions
+          - tfclassify: ${{ steps.versions.outputs.tfclassify }}
+          - terraform: ${{ steps.versions.outputs.terraform }}
+
+          ### Create phase
+          - Expected exit code: ${{ steps.classify-create.outputs.expected }}
+          - Actual exit code: ${{ steps.classify-create.outputs.actual }}
+
+          ### Destroy phase
+          - Expected exit code: ${{ steps.classify-destroy.outputs.expected }}
+          - Actual exit code: ${{ steps.classify-destroy.outputs.actual }}
+          EOF
+
+          gh issue create \
+            --title "[verify] ${{ matrix.use-case }} failed ($(date -u +%Y-%m-%d))" \
+            --label "verification" \
+            --body-file /tmp/issue-body.md

--- a/docs/cr/CR-0022-nightly-verification-workflow.md
+++ b/docs/cr/CR-0022-nightly-verification-workflow.md
@@ -1,0 +1,177 @@
+---
+id: "CR-0022"
+status: implemented
+date: 2026-02-15
+requestor: jokarl
+stakeholders:
+  - jokarl
+priority: medium
+target-version: next
+---
+
+# Nightly Verification Workflow
+
+## Change Summary
+
+Add a GitHub Actions workflow that runs nightly (and on-demand) to verify the latest released tfclassify binaries against real Azure infrastructure. Four use cases exercise the full stack: Terraform plan parsing, plugin gRPC communication, classification output, and exit code correctness. A pre-flight cleanup job ensures the target resource group starts empty, and failures automatically open GitHub issues with diagnostic context.
+
+## Motivation and Background
+
+Unit tests cover classification logic in isolation, but they cannot catch regressions in:
+
+- Terraform plan JSON format changes across provider versions
+- Plugin gRPC communication between separately-released CLI and plugin binaries
+- Azure provider behavior changes that affect resource attribute shapes
+- Exit code calculation against real plan output
+
+The existing CI pipeline (CR-0020) validates build and test on every PR, but uses synthetic test fixtures. A nightly verification against real infrastructure provides confidence that the latest released binaries work end-to-end.
+
+## Change Drivers
+
+* No integration testing against real Azure resources
+* CLI and plugin are released independently -- version compatibility needs ongoing validation
+* Terraform provider updates can change plan JSON structure without warning
+* Exit code correctness is critical for CI/CD consumers of tfclassify
+
+## Proposed Change
+
+### Use Cases
+
+Four parallel use cases, each in its own folder under `testdata/e2e/`:
+
+| Use case | Resources | Plugin | Create exit | Destroy exit |
+|---|---|---|---|---|
+| `role-assignment-privileged` | Managed identity + Owner role assignment | azurerm (privilege) | 1 (standard) | 2 (critical) |
+| `nsg-open-inbound` | NSG + permissive inbound rule | azurerm (network) | 1 (standard) | 2 (critical) |
+| `route-table` | Route table + Internet route | none | 1 (standard) | 1 (standard) |
+| `role-assignment-reader` | Managed identity + Reader role assignment | azurerm (privilege) | 1 (standard) | 2 (critical) |
+
+### Workflow Structure
+
+Two jobs:
+
+1. **cleanup** -- Uses `azure/login` + `az cli` to delete all existing resources and role assignments from the lab resource group, ensuring each run starts fresh even if a previous run failed and left resources behind.
+
+2. **verify** (matrix x4, fail-fast: false) -- Downloads latest released CLI and plugin binaries, runs Terraform init/plan/apply/destroy against each use case, and compares tfclassify exit codes against expected values in `expected.json`.
+
+### Authentication
+
+GitHub OIDC federated credentials with the Azure service principal. The Terraform azurerm provider authenticates via `ARM_*` environment variables. The cleanup job uses `azure/login@v2` for `az cli` access.
+
+### Failure Handling
+
+- Per-use-case `terraform destroy -auto-approve` cleanup runs on `if: always()` when apply was attempted
+- Pre-flight cleanup job deletes all resources before the matrix starts
+- On failure, `gh issue create` opens an issue with binary versions, expected vs actual exit codes, and a link to the workflow run
+
+## Files Created
+
+```
+.github/workflows/verify.yml
+testdata/e2e/role-assignment-privileged/{main.tf,.tfclassify.hcl,expected.json}
+testdata/e2e/nsg-open-inbound/{main.tf,.tfclassify.hcl,expected.json}
+testdata/e2e/route-table/{main.tf,.tfclassify.hcl,expected.json}
+testdata/e2e/role-assignment-reader/{main.tf,.tfclassify.hcl,expected.json}
+```
+
+## Requirements
+
+### Functional Requirements
+
+1. The workflow **MUST** run on a nightly schedule (cron) and support manual `workflow_dispatch`
+2. The workflow **MUST** download the latest released CLI and plugin binaries (not build from source)
+3. Each use case **MUST** run Terraform plan, classify with tfclassify, and compare exit codes to expected values
+4. The workflow **MUST** clean up Azure resources after each use case, including on failure
+5. The workflow **MUST** delete all pre-existing resources from the lab resource group before tests start
+6. The workflow **MUST** open a GitHub issue on failure with diagnostic information
+
+### Non-Functional Requirements
+
+1. Matrix jobs **MUST** use `fail-fast: false` so one failure does not cancel others
+2. The workflow **MUST** use OIDC authentication (no stored secrets for Azure credentials)
+3. Plan JSON output **MUST** be logged in collapsible groups for debugging
+
+## Acceptance Criteria
+
+### AC-1: Nightly schedule triggers verification
+
+```gherkin
+Given the verify workflow is configured with cron schedule '0 2 * * *'
+When the scheduled time arrives
+Then all four matrix jobs run against real Azure infrastructure
+  And each job compares tfclassify exit codes against expected.json
+```
+
+### AC-2: Clean start on every run
+
+```gherkin
+Given previous resources may exist in the lab resource group
+When the workflow starts
+Then the cleanup job deletes all role assignments and resources
+  And the verify jobs begin with an empty resource group
+```
+
+### AC-3: Resource cleanup on failure
+
+```gherkin
+Given a use case where terraform apply succeeded
+When a subsequent step fails
+Then terraform destroy runs to clean up created resources
+```
+
+### AC-4: Issue creation on failure
+
+```gherkin
+Given a use case where the actual exit code differs from expected
+When the job fails
+Then a GitHub issue is created with label "verification"
+  And the issue body contains binary versions and exit code comparison
+  And the issue body contains a link to the workflow run
+```
+
+### AC-5: Exit code verification
+
+```gherkin
+Given use case "role-assignment-privileged" with Owner role assignment
+When tfclassify classifies the create plan
+Then the exit code is 1 (standard)
+When tfclassify classifies the destroy plan
+Then the exit code is 2 (critical)
+```
+
+## Scope Boundaries
+
+### In Scope
+
+* Nightly verification workflow with cleanup and matrix jobs
+* Four e2e use cases covering plugin and core-only classification
+* Automatic issue creation on failure
+* Pre-flight resource cleanup via az cli
+
+### Out of Scope
+
+* Slack/Teams notifications on failure
+* Automatic retry of failed runs
+* Performance benchmarking
+* Additional cloud providers (AWS, GCP)
+
+## Impact Assessment
+
+### User Impact
+
+None -- this is a CI-only workflow with no changes to the CLI or library.
+
+### Technical Impact
+
+Adds a new workflow and test fixtures. No changes to existing code, tests, or build artifacts.
+
+## Dependencies
+
+* Azure OIDC federated credential configured for the GitHub repository
+* Lab resource group `rg-lab-johan.karlsson` must exist in the Azure subscription
+* At least one CLI release and one plugin release must exist
+
+## Related Items
+
+* CR-0020: GitHub Actions CI/CD Workflows (established the CI pipeline this builds upon)
+* CR-0006: gRPC Protocol and Plugin Host (the plugin communication being verified)

--- a/docs/cr/CR-0023-detailed-exitcode-flag.md
+++ b/docs/cr/CR-0023-detailed-exitcode-flag.md
@@ -1,0 +1,312 @@
+---
+name: cr-0023-detailed-exitcode-flag
+description: Add --detailed-exitcode flag to control exit code behavior for CI-friendly operation.
+id: "CR-0023"
+status: "proposed"
+date: 2026-02-15
+requestor: jokarl
+stakeholders:
+  - jokarl
+priority: "medium"
+target-version: next
+---
+
+# Add `--detailed-exitcode` flag for CI-friendly exit codes
+
+## Change Summary
+
+Currently tfclassify always exits with classification-based exit codes (e.g. `critical=2`, `standard=1`, `auto=0`). This makes it difficult to distinguish between "the tool ran successfully and classified changes" and "the tool failed due to an internal error" in CI pipelines. This CR proposes a `--detailed-exitcode` flag that opts into the current precedence-based exit codes. Without the flag, tfclassify exits `0` for any successful classification, reserving non-zero for actual errors.
+
+## Motivation and Background
+
+In CI/CD pipelines, exit codes serve as the primary signaling mechanism. Many CI systems (GitHub Actions, Azure Pipelines, Jenkins) treat any non-zero exit code as a failure and halt the pipeline. The current behavior — where a successful classification of "critical" exits with code 2 — forces pipeline authors to work around this by wrapping tfclassify in `set +e` blocks or `|| true` suffixes, then parsing the output separately.
+
+Terraform itself solved this exact problem with its `-detailed-exitcode` flag on `terraform plan`: without it, plan exits 0 on success regardless of whether changes exist; with it, exit code 2 signals "changes present". This is a well-understood pattern in the Terraform ecosystem.
+
+## Change Drivers
+
+* CI/CD ergonomics — pipeline authors need to distinguish "tool succeeded" from "tool failed" without shell workarounds
+* Terraform ecosystem convention — `-detailed-exitcode` is an established pattern users already understand
+* JSON/GitHub output formats already embed the classification result, making exit codes redundant when parsing structured output
+
+## Current State
+
+tfclassify always exits with precedence-derived exit codes:
+
+```
+os.Exit(result.OverallExitCode)
+```
+
+The exit code is calculated from the classification's position in the `precedence` list:
+
+| Classification position | Exit code | Meaning |
+|------------------------|-----------|---------|
+| Last (lowest)          | 0         | Auto — proceed |
+| Second-to-last         | 1         | Standard |
+| ...                    | ...       | ... |
+| First (highest)        | N-1       | Critical — block |
+
+Internal errors (config load failure, plan parse failure, plugin errors) return exit code 1 via Cobra's error handling, which collides with classification exit codes when `N >= 3`.
+
+### Current State Diagram
+
+```mermaid
+flowchart TD
+    A[tfclassify runs] --> B{Internal error?}
+    B -->|Yes| C["os.Exit(1) via Cobra"]
+    B -->|No| D[Classify resources]
+    D --> E["os.Exit(result.OverallExitCode)"]
+    E --> F["Exit 0 = auto"]
+    E --> G["Exit 1 = standard"]
+    E --> H["Exit 2 = critical"]
+```
+
+Note how exit code 1 is ambiguous — it could mean "internal error" or "standard classification".
+
+## Proposed Change
+
+Add a `--detailed-exitcode` flag (short: `-d`) to the root command. When absent, tfclassify exits `0` for any successful classification run. When present, the current precedence-based exit codes apply.
+
+Additionally, reserve exit code `1` exclusively for internal errors to avoid ambiguity. Classification exit codes start from `0` (lowest precedence) and increase, but `1` is skipped — the lowest non-auto classification gets exit code `2`.
+
+### Proposed State Diagram
+
+```mermaid
+flowchart TD
+    A[tfclassify runs] --> B{Internal error?}
+    B -->|Yes| C["os.Exit(1) — always means error"]
+    B -->|No| D[Classify resources]
+    D --> E{--detailed-exitcode?}
+    E -->|No| F["os.Exit(0) — success, parse output for result"]
+    E -->|Yes| G["os.Exit(result.OverallExitCode)"]
+    G --> H["Exit 0 = auto"]
+    G --> I["Exit 2+ = classification-based"]
+```
+
+## Requirements
+
+### Functional Requirements
+
+1. The CLI **MUST** accept a `--detailed-exitcode` flag (boolean, default `false`)
+2. When `--detailed-exitcode` is not set, the CLI **MUST** exit `0` after any successful classification, regardless of the overall classification result
+3. When `--detailed-exitcode` is set, the CLI **MUST** exit with the precedence-derived exit code (current behavior)
+4. The CLI **MUST** exit `1` for internal errors (config failures, plan parse failures, plugin failures) regardless of the `--detailed-exitcode` flag
+5. The `exit_code` field in JSON output **MUST** always contain the precedence-derived exit code, regardless of the `--detailed-exitcode` flag (output content is unaffected)
+6. The `exit_code` in GitHub Actions output format **MUST** always contain the precedence-derived exit code, regardless of the `--detailed-exitcode` flag
+
+### Non-Functional Requirements
+
+1. The change **MUST** not affect classification logic, output formatting, or plugin execution
+2. The change **MUST** be backward-compatible: users who add `--detailed-exitcode` get the exact same behavior as before
+
+## Affected Components
+
+* `cmd/tfclassify/main.go` — flag registration, exit code logic in `run()`
+* `cmd/tfclassify/main_test.go` — CLI integration tests for exit code behavior
+* `README.md` — CLI reference table, exit code documentation
+
+## Scope Boundaries
+
+### In Scope
+
+* Adding `--detailed-exitcode` boolean flag to root command
+* Changing default exit behavior to always return 0 on success
+* Updating CLI reference documentation in README
+* Updating exit code table in README
+* Tests for both modes
+
+### Out of Scope ("Here, But Not Further")
+
+* Reserving exit code 1 for errors only (skipping 1 in classification codes) — this is a separate concern that may warrant its own CR
+* Adding exit code control to the `github` output format beyond what already exists
+* Configuration-file-based exit code control — CLI flag is sufficient
+* Short flag `-d` — defer unless it does not conflict with existing flags
+
+## Alternative Approaches Considered
+
+* **Invert the default (opt-out with `--no-detailed-exitcode`):** Preserves backward compatibility but breaks the Terraform convention where the detailed behavior is opt-in. Also makes the common CI case require no extra flags.
+* **`--exit-code=always|classification|never`:** More flexible but over-engineered for a boolean choice. Could be revisited if more exit code modes emerge.
+* **Config-file setting (`defaults.detailed_exitcode = true`):** Mixes runtime behavior with classification config. The flag is a better fit since it's a pipeline concern, not a classification concern.
+
+## Impact Assessment
+
+### User Impact
+
+This is a **breaking change** to default exit code behavior. Users who rely on non-zero exit codes from tfclassify without `--detailed-exitcode` will need to add the flag to their pipeline scripts.
+
+Migration path: add `--detailed-exitcode` to any existing pipeline invocation that checks `$?` for classification results.
+
+### Technical Impact
+
+Minimal. The change is confined to the `run()` function in `main.go` — a single conditional around `os.Exit()`. No changes to classification logic, output formatting, or plugin system.
+
+### Business Impact
+
+Improves CI/CD adoption by making the default behavior pipeline-friendly. Reduces onboarding friction for new users integrating tfclassify into existing pipelines.
+
+## Implementation Approach
+
+Single-phase implementation — the change is small and self-contained.
+
+1. Add `--detailed-exitcode` flag to root command in `init()`
+2. Modify `run()` to conditionally use `os.Exit(0)` vs `os.Exit(result.OverallExitCode)`
+3. Update tests to cover both modes
+4. Update README CLI reference and exit code documentation
+
+### Implementation Flow
+
+```mermaid
+flowchart LR
+    subgraph Phase1["Implementation"]
+        A1[Add flag] --> A2[Modify exit logic]
+        A2 --> A3[Update tests]
+        A3 --> A4[Update README]
+    end
+```
+
+## Test Strategy
+
+### Tests to Add
+
+| Test File | Test Name | Description | Inputs | Expected Output |
+|-----------|-----------|-------------|--------|-----------------|
+| `cmd/tfclassify/main_test.go` | `TestCLI_DefaultExitCodeZeroOnSuccess` | Without `--detailed-exitcode`, successful classification exits 0 | Plan with critical changes, no `--detailed-exitcode` | Exit code 0, output contains "critical" |
+| `cmd/tfclassify/main_test.go` | `TestCLI_DetailedExitCodeFlag` | With `--detailed-exitcode`, classification exit codes apply | Plan with critical changes + `--detailed-exitcode` | Exit code matches precedence position |
+| `cmd/tfclassify/main_test.go` | `TestCLI_ErrorExitCodeUnaffectedByFlag` | Internal errors always exit 1 regardless of flag | Invalid plan path, with and without `--detailed-exitcode` | Exit code 1 in both cases |
+
+### Tests to Modify
+
+| Test File | Test Name | Current Behavior | New Behavior | Reason for Change |
+|-----------|-----------|------------------|--------------|-------------------|
+| `cmd/tfclassify/main_test.go` | `TestCLI_ExitCodes` | Expects non-zero exit for classifications | Expects exit 0 without `--detailed-exitcode`, non-zero with it | Default behavior changes |
+
+### Tests to Remove
+
+Not applicable — no tests become obsolete.
+
+## Acceptance Criteria
+
+### AC-1: Default exit code is 0 on successful classification
+
+```gherkin
+Given a valid plan file with critical resource changes
+  And a valid configuration file
+When tfclassify runs without the --detailed-exitcode flag
+Then the process exits with code 0
+  And the output contains the correct classification result
+```
+
+### AC-2: Detailed exit codes with flag
+
+```gherkin
+Given a valid plan file with critical resource changes
+  And a valid configuration with precedence ["critical", "standard", "auto"]
+When tfclassify runs with the --detailed-exitcode flag
+Then the process exits with code 2 (critical's precedence-derived code)
+```
+
+### AC-3: Internal errors always exit 1
+
+```gherkin
+Given an invalid or nonexistent plan file path
+When tfclassify runs without the --detailed-exitcode flag
+Then the process exits with code 1
+  And stderr contains an error message
+```
+
+### AC-4: JSON output unaffected by flag
+
+```gherkin
+Given a valid plan file with critical resource changes
+When tfclassify runs with --output json without --detailed-exitcode
+Then the process exits with code 0
+  And the JSON output contains "exit_code": 2
+```
+
+### AC-5: GitHub output unaffected by flag
+
+```gherkin
+Given a valid plan file with critical resource changes
+When tfclassify runs with --output github without --detailed-exitcode
+Then the process exits with code 0
+  And the output contains "exit_code=2" for GitHub Actions
+```
+
+## Quality Standards Compliance
+
+### Build & Compilation
+
+- [ ] Code compiles/builds without errors
+- [ ] No new compiler warnings introduced
+
+### Linting & Code Style
+
+- [ ] All linter checks pass with zero warnings/errors
+- [ ] Code follows project coding conventions and style guides
+
+### Test Execution
+
+- [ ] All existing tests pass after implementation
+- [ ] All new tests pass
+- [ ] Test coverage meets project requirements for changed code
+
+### Documentation
+
+- [ ] README CLI reference table updated with `--detailed-exitcode` flag
+- [ ] README exit code section updated to describe both modes
+- [ ] Inline code comments updated in `main.go`
+
+### Code Review
+
+- [ ] Changes submitted via pull request
+- [ ] PR title follows Conventional Commits format
+- [ ] Code review completed and approved
+- [ ] Changes squash-merged to maintain linear history
+
+### Verification Commands
+
+```bash
+# Build verification
+make build
+
+# Lint verification
+make lint
+
+# Test execution
+make test
+
+# Vulnerability check
+govulncheck ./...
+```
+
+## Risks and Mitigation
+
+### Risk 1: Breaking existing CI pipelines that rely on non-zero exit codes
+
+**Likelihood:** high
+**Impact:** medium
+**Mitigation:** Document the breaking change clearly in release notes. The migration is a one-line change (add `--detailed-exitcode` to the command). Consider a deprecation warning in the release prior to the change.
+
+### Risk 2: Exit code 1 collision between errors and classifications
+
+**Likelihood:** low (only with 3+ precedence levels)
+**Impact:** low
+**Mitigation:** This is a pre-existing issue not introduced by this CR. Document that exit code 1 without `--detailed-exitcode` always means error. With `--detailed-exitcode`, the existing precedence mapping applies unchanged.
+
+## Dependencies
+
+* No external dependencies
+
+## Estimated Effort
+
+Small — approximately 2-4 hours including tests and documentation.
+
+## Decision Outcome
+
+Chosen approach: "opt-in `--detailed-exitcode` flag", because it follows the Terraform convention (`terraform plan -detailed-exitcode`), makes the default CI-friendly (exit 0 on success), and is the simplest change with the clearest mental model.
+
+## Related Items
+
+* Terraform's `-detailed-exitcode` on `terraform plan` — prior art and naming convention
+* Current exit code logic: `pkg/classify/classifier.go:108` (`getExitCode`)
+* CLI entry point: `cmd/tfclassify/main.go:148` (`os.Exit(result.OverallExitCode)`)

--- a/testdata/e2e/nsg-open-inbound/.tfclassify.hcl
+++ b/testdata/e2e/nsg-open-inbound/.tfclassify.hcl
@@ -1,0 +1,43 @@
+plugin "azurerm" {
+  enabled = true
+
+  config {
+    privilege_enabled = false
+    network_enabled   = true
+    keyvault_enabled  = false
+  }
+}
+
+classification "critical" {
+  description = "Requires security review"
+
+  rule {
+    resource = ["*_role_*", "*_security_group", "*_security_rule"]
+    actions  = ["delete"]
+  }
+}
+
+classification "standard" {
+  description = "Standard change"
+
+  rule {
+    resource = ["*"]
+  }
+}
+
+classification "auto" {
+  description = "Auto-approved"
+
+  rule {
+    resource = ["*"]
+    actions  = ["no-op"]
+  }
+}
+
+precedence = ["critical", "standard", "auto"]
+
+defaults {
+  unclassified   = "standard"
+  no_changes     = "auto"
+  plugin_timeout = "30s"
+}

--- a/testdata/e2e/nsg-open-inbound/expected.json
+++ b/testdata/e2e/nsg-open-inbound/expected.json
@@ -1,0 +1,4 @@
+{
+  "create": { "exit_code": 1, "classification": "standard" },
+  "destroy": { "exit_code": 2, "classification": "critical" }
+}

--- a/testdata/e2e/nsg-open-inbound/main.tf
+++ b/testdata/e2e/nsg-open-inbound/main.tf
@@ -1,0 +1,46 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+  subscription_id                 = "0a271008-02cf-4a50-9bb3-afc7c4aed74c"
+  resource_provider_registrations = "none"
+}
+
+resource "random_id" "suffix" {
+  byte_length = 4
+}
+
+data "azurerm_resource_group" "lab" {
+  name = "rg-lab-johan.karlsson"
+}
+
+resource "azurerm_network_security_group" "test" {
+  name                = "nsg-verify-${random_id.suffix.hex}"
+  resource_group_name = data.azurerm_resource_group.lab.name
+  location            = data.azurerm_resource_group.lab.location
+}
+
+resource "azurerm_network_security_rule" "test" {
+  name                        = "allow-all-inbound"
+  priority                    = 100
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "*"
+  source_port_range           = "*"
+  destination_port_range      = "*"
+  source_address_prefix       = "*"
+  destination_address_prefix  = "*"
+  resource_group_name         = data.azurerm_resource_group.lab.name
+  network_security_group_name = azurerm_network_security_group.test.name
+}

--- a/testdata/e2e/role-assignment-privileged/.tfclassify.hcl
+++ b/testdata/e2e/role-assignment-privileged/.tfclassify.hcl
@@ -1,0 +1,43 @@
+plugin "azurerm" {
+  enabled = true
+
+  config {
+    privilege_enabled = true
+    network_enabled   = false
+    keyvault_enabled  = false
+  }
+}
+
+classification "critical" {
+  description = "Requires security review"
+
+  rule {
+    resource = ["*_role_*", "*_security_group", "*_security_rule"]
+    actions  = ["delete"]
+  }
+}
+
+classification "standard" {
+  description = "Standard change"
+
+  rule {
+    resource = ["*"]
+  }
+}
+
+classification "auto" {
+  description = "Auto-approved"
+
+  rule {
+    resource = ["*"]
+    actions  = ["no-op"]
+  }
+}
+
+precedence = ["critical", "standard", "auto"]
+
+defaults {
+  unclassified   = "standard"
+  no_changes     = "auto"
+  plugin_timeout = "30s"
+}

--- a/testdata/e2e/role-assignment-privileged/expected.json
+++ b/testdata/e2e/role-assignment-privileged/expected.json
@@ -1,0 +1,4 @@
+{
+  "create": { "exit_code": 1, "classification": "standard" },
+  "destroy": { "exit_code": 2, "classification": "critical" }
+}

--- a/testdata/e2e/role-assignment-privileged/main.tf
+++ b/testdata/e2e/role-assignment-privileged/main.tf
@@ -1,0 +1,38 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+  subscription_id                 = "0a271008-02cf-4a50-9bb3-afc7c4aed74c"
+  resource_provider_registrations = "none"
+}
+
+resource "random_id" "suffix" {
+  byte_length = 4
+}
+
+data "azurerm_resource_group" "lab" {
+  name = "rg-lab-johan.karlsson"
+}
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "id-verify-priv-${random_id.suffix.hex}"
+  resource_group_name = data.azurerm_resource_group.lab.name
+  location            = data.azurerm_resource_group.lab.location
+}
+
+resource "azurerm_role_assignment" "test" {
+  scope                = data.azurerm_resource_group.lab.id
+  role_definition_name = "Owner"
+  principal_id         = azurerm_user_assigned_identity.test.principal_id
+}

--- a/testdata/e2e/role-assignment-reader/.tfclassify.hcl
+++ b/testdata/e2e/role-assignment-reader/.tfclassify.hcl
@@ -1,0 +1,43 @@
+plugin "azurerm" {
+  enabled = true
+
+  config {
+    privilege_enabled = true
+    network_enabled   = false
+    keyvault_enabled  = false
+  }
+}
+
+classification "critical" {
+  description = "Requires security review"
+
+  rule {
+    resource = ["*_role_*", "*_security_group", "*_security_rule"]
+    actions  = ["delete"]
+  }
+}
+
+classification "standard" {
+  description = "Standard change"
+
+  rule {
+    resource = ["*"]
+  }
+}
+
+classification "auto" {
+  description = "Auto-approved"
+
+  rule {
+    resource = ["*"]
+    actions  = ["no-op"]
+  }
+}
+
+precedence = ["critical", "standard", "auto"]
+
+defaults {
+  unclassified   = "standard"
+  no_changes     = "auto"
+  plugin_timeout = "30s"
+}

--- a/testdata/e2e/role-assignment-reader/expected.json
+++ b/testdata/e2e/role-assignment-reader/expected.json
@@ -1,0 +1,4 @@
+{
+  "create": { "exit_code": 1, "classification": "standard" },
+  "destroy": { "exit_code": 2, "classification": "critical" }
+}

--- a/testdata/e2e/role-assignment-reader/main.tf
+++ b/testdata/e2e/role-assignment-reader/main.tf
@@ -1,0 +1,38 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+  subscription_id                 = "0a271008-02cf-4a50-9bb3-afc7c4aed74c"
+  resource_provider_registrations = "none"
+}
+
+resource "random_id" "suffix" {
+  byte_length = 4
+}
+
+data "azurerm_resource_group" "lab" {
+  name = "rg-lab-johan.karlsson"
+}
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "id-verify-reader-${random_id.suffix.hex}"
+  resource_group_name = data.azurerm_resource_group.lab.name
+  location            = data.azurerm_resource_group.lab.location
+}
+
+resource "azurerm_role_assignment" "test" {
+  scope                = data.azurerm_resource_group.lab.id
+  role_definition_name = "Reader"
+  principal_id         = azurerm_user_assigned_identity.test.principal_id
+}

--- a/testdata/e2e/route-table/.tfclassify.hcl
+++ b/testdata/e2e/route-table/.tfclassify.hcl
@@ -1,0 +1,33 @@
+classification "critical" {
+  description = "Requires security review"
+
+  rule {
+    resource = ["*_role_*", "*_security_group", "*_security_rule"]
+    actions  = ["delete"]
+  }
+}
+
+classification "standard" {
+  description = "Standard change"
+
+  rule {
+    resource = ["*"]
+  }
+}
+
+classification "auto" {
+  description = "Auto-approved"
+
+  rule {
+    resource = ["*"]
+    actions  = ["no-op"]
+  }
+}
+
+precedence = ["critical", "standard", "auto"]
+
+defaults {
+  unclassified   = "standard"
+  no_changes     = "auto"
+  plugin_timeout = "30s"
+}

--- a/testdata/e2e/route-table/expected.json
+++ b/testdata/e2e/route-table/expected.json
@@ -1,0 +1,4 @@
+{
+  "create": { "exit_code": 1, "classification": "standard" },
+  "destroy": { "exit_code": 1, "classification": "standard" }
+}

--- a/testdata/e2e/route-table/main.tf
+++ b/testdata/e2e/route-table/main.tf
@@ -1,0 +1,40 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+  subscription_id                 = "0a271008-02cf-4a50-9bb3-afc7c4aed74c"
+  resource_provider_registrations = "none"
+}
+
+resource "random_id" "suffix" {
+  byte_length = 4
+}
+
+data "azurerm_resource_group" "lab" {
+  name = "rg-lab-johan.karlsson"
+}
+
+resource "azurerm_route_table" "test" {
+  name                = "rt-verify-${random_id.suffix.hex}"
+  resource_group_name = data.azurerm_resource_group.lab.name
+  location            = data.azurerm_resource_group.lab.location
+}
+
+resource "azurerm_route" "test" {
+  name                = "internet-route"
+  resource_group_name = data.azurerm_resource_group.lab.name
+  route_table_name    = azurerm_route_table.test.name
+  address_prefix      = "10.100.0.0/16"
+  next_hop_type       = "Internet"
+}


### PR DESCRIPTION
Add verify.yml workflow with cleanup + matrix verify jobs, four e2e use cases (role-assignment-privileged, nsg-open-inbound, route-table, role-assignment-reader), and CR-0022 document. Rename existing CR-0022 (detailed-exitcode) to CR-0023.