### PR TITLE
test: add e2e scenarios for Terraform module classification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,8 @@ jobs:
           - data-plane-detection
           - control-plane-patterns
           - custom-role-cross-reference
+          - modules-pluginless
+          - modules-plugin
         include:
           # custom-role-cross-reference creates an azurerm_role_definition, which
           # requires Microsoft.Authorization/roleDefinitions/write — a permission

--- a/testdata/e2e/modules-plugin/.tfclassify.hcl
+++ b/testdata/e2e/modules-plugin/.tfclassify.hcl
@@ -1,0 +1,45 @@
+plugin "azurerm" {
+  enabled = true
+  source  = "github.com/jokarl/tfclassify"
+  version = "0.1.0"
+}
+
+classification "critical" {
+  description = "Requires security review"
+
+  rule {
+    resource = ["*_role_*", "*_security_group", "*_security_rule"]
+    actions  = ["delete"]
+  }
+
+  azurerm {
+    privilege_escalation {
+      actions = ["Microsoft.Authorization/*"]
+    }
+  }
+}
+
+classification "standard" {
+  description = "Standard change"
+
+  rule {
+    resource = ["*"]
+  }
+}
+
+classification "auto" {
+  description = "Auto-approved"
+
+  rule {
+    resource = ["*"]
+    actions  = ["no-op"]
+  }
+}
+
+precedence = ["critical", "standard", "auto"]
+
+defaults {
+  unclassified   = "standard"
+  no_changes     = "auto"
+  plugin_timeout = "30s"
+}

--- a/testdata/e2e/modules-plugin/expected.json
+++ b/testdata/e2e/modules-plugin/expected.json
@@ -1,0 +1,4 @@
+{
+  "create": { "exit_code": 2, "classification": "critical" },
+  "destroy": { "exit_code": 2, "classification": "critical" }
+}

--- a/testdata/e2e/modules-plugin/main.tf
+++ b/testdata/e2e/modules-plugin/main.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+  resource_provider_registrations = "none"
+}
+
+resource "random_id" "suffix" {
+  byte_length = 4
+}
+
+variable "resource_group_name" {}
+
+data "azurerm_resource_group" "lab" {
+  name = var.resource_group_name
+}
+
+module "identity" {
+  source = "./modules/identity"
+
+  name_suffix         = random_id.suffix.hex
+  resource_group_name = data.azurerm_resource_group.lab.name
+  resource_group_id   = data.azurerm_resource_group.lab.id
+  location            = data.azurerm_resource_group.lab.location
+}

--- a/testdata/e2e/modules-plugin/modules/identity/main.tf
+++ b/testdata/e2e/modules-plugin/modules/identity/main.tf
@@ -1,0 +1,16 @@
+variable "name_suffix" {}
+variable "resource_group_name" {}
+variable "resource_group_id" {}
+variable "location" {}
+
+resource "azurerm_user_assigned_identity" "this" {
+  name                = "id-mod-${var.name_suffix}"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+}
+
+resource "azurerm_role_assignment" "this" {
+  scope                = var.resource_group_id
+  role_definition_name = "Owner"
+  principal_id         = azurerm_user_assigned_identity.this.principal_id
+}

--- a/testdata/e2e/modules-pluginless/.tfclassify.hcl
+++ b/testdata/e2e/modules-pluginless/.tfclassify.hcl
@@ -1,0 +1,33 @@
+classification "critical" {
+  description = "Requires security review"
+
+  rule {
+    resource = ["*_security_group", "*_security_rule"]
+    actions  = ["delete"]
+  }
+}
+
+classification "standard" {
+  description = "Standard change"
+
+  rule {
+    resource = ["*"]
+  }
+}
+
+classification "auto" {
+  description = "Auto-approved"
+
+  rule {
+    resource = ["*"]
+    actions  = ["no-op"]
+  }
+}
+
+precedence = ["critical", "standard", "auto"]
+
+defaults {
+  unclassified   = "standard"
+  no_changes     = "auto"
+  plugin_timeout = "30s"
+}

--- a/testdata/e2e/modules-pluginless/expected.json
+++ b/testdata/e2e/modules-pluginless/expected.json
@@ -1,0 +1,4 @@
+{
+  "create": { "exit_code": 1, "classification": "standard" },
+  "destroy": { "exit_code": 2, "classification": "critical" }
+}

--- a/testdata/e2e/modules-pluginless/main.tf
+++ b/testdata/e2e/modules-pluginless/main.tf
@@ -1,0 +1,35 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+  resource_provider_registrations = "none"
+}
+
+resource "random_id" "suffix" {
+  byte_length = 4
+}
+
+variable "resource_group_name" {}
+
+data "azurerm_resource_group" "lab" {
+  name = var.resource_group_name
+}
+
+module "network" {
+  source = "./modules/network"
+
+  name_suffix         = random_id.suffix.hex
+  resource_group_name = data.azurerm_resource_group.lab.name
+  location            = data.azurerm_resource_group.lab.location
+}

--- a/testdata/e2e/modules-pluginless/modules/network/main.tf
+++ b/testdata/e2e/modules-pluginless/modules/network/main.tf
@@ -1,0 +1,15 @@
+variable "name_suffix" {}
+variable "resource_group_name" {}
+variable "location" {}
+
+resource "azurerm_network_security_group" "this" {
+  name                = "nsg-mod-${var.name_suffix}"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+}
+
+resource "azurerm_route_table" "this" {
+  name                = "rt-mod-${var.name_suffix}"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+}


### PR DESCRIPTION
Add two module-based e2e test scenarios to verify that tfclassify correctly classifies resources created inside Terraform modules:

- modules-pluginless: local module with NSG + route table, pattern-only classification (no plugin)
- modules-plugin: local module with managed identity + Owner role assignment, azurerm plugin detects privilege escalation