### PR TITLE
test: clean up e2e configs and add network-exposure coverage

### DIFF
--- a/testdata/e2e/control-plane-patterns/.tfclassify.hcl
+++ b/testdata/e2e/control-plane-patterns/.tfclassify.hcl
@@ -8,7 +8,7 @@ classification "critical" {
   description = "Critical - authorization control access detected"
 
   rule {
-    resource = ["*_role_*", "*_security_group", "*_security_rule"]
+    resource = ["*_role_*"]
     actions  = ["delete"]
   }
 

--- a/testdata/e2e/custom-role-cross-reference/.tfclassify.hcl
+++ b/testdata/e2e/custom-role-cross-reference/.tfclassify.hcl
@@ -8,7 +8,7 @@ classification "critical" {
   description = "Critical - authorization control access via custom role"
 
   rule {
-    resource = ["*_role_*", "*_security_group", "*_security_rule"]
+    resource = ["*_role_*"]
     actions  = ["delete"]
   }
 

--- a/testdata/e2e/data-plane-detection/.tfclassify.hcl
+++ b/testdata/e2e/data-plane-detection/.tfclassify.hcl
@@ -8,7 +8,7 @@ classification "critical" {
   description = "Critical - data plane storage access detected"
 
   rule {
-    resource = ["*_role_*", "*_security_group", "*_security_rule"]
+    resource = ["*_role_*"]
     actions  = ["delete"]
   }
 

--- a/testdata/e2e/keyvault-destructive/.tfclassify.hcl
+++ b/testdata/e2e/keyvault-destructive/.tfclassify.hcl
@@ -8,7 +8,7 @@ classification "critical" {
   description = "Requires security review"
 
   rule {
-    resource = ["*_role_*", "*_security_group", "*_security_rule", "*_key_vault*"]
+    resource = ["*_key_vault*"]
     actions  = ["delete"]
   }
 

--- a/testdata/e2e/modules-plugin/.tfclassify.hcl
+++ b/testdata/e2e/modules-plugin/.tfclassify.hcl
@@ -8,7 +8,7 @@ classification "critical" {
   description = "Requires security review"
 
   rule {
-    resource = ["*_role_*", "*_security_group", "*_security_rule"]
+    resource = ["*_role_*"]
     actions  = ["delete"]
   }
 

--- a/testdata/e2e/nsg-open-inbound/.tfclassify.hcl
+++ b/testdata/e2e/nsg-open-inbound/.tfclassify.hcl
@@ -1,9 +1,20 @@
+plugin "azurerm" {
+  enabled = true
+  source  = "github.com/jokarl/tfclassify"
+  version = "0.1.0"
+}
+
 classification "critical" {
   description = "Requires security review"
 
   rule {
-    resource = ["*_role_*", "*_security_group", "*_security_rule"]
+    resource = ["*_security_group", "*_security_rule"]
     actions  = ["delete"]
+  }
+
+  # Detect inbound allow rules with overly permissive sources
+  azurerm {
+    network_exposure {}
   }
 }
 

--- a/testdata/e2e/nsg-open-inbound/expected.json
+++ b/testdata/e2e/nsg-open-inbound/expected.json
@@ -1,4 +1,4 @@
 {
-  "create": { "exit_code": 1, "classification": "standard" },
+  "create": { "exit_code": 2, "classification": "critical" },
   "destroy": { "exit_code": 2, "classification": "critical" }
 }

--- a/testdata/e2e/role-assignment-privileged/.tfclassify.hcl
+++ b/testdata/e2e/role-assignment-privileged/.tfclassify.hcl
@@ -8,7 +8,7 @@ classification "critical" {
   description = "Requires security review"
 
   rule {
-    resource = ["*_role_*", "*_security_group", "*_security_rule"]
+    resource = ["*_role_*"]
     actions  = ["delete"]
   }
 

--- a/testdata/e2e/role-assignment-reader/.tfclassify.hcl
+++ b/testdata/e2e/role-assignment-reader/.tfclassify.hcl
@@ -2,7 +2,7 @@ classification "critical" {
   description = "Requires security review"
 
   rule {
-    resource = ["*_role_*", "*_security_group", "*_security_rule"]
+    resource = ["*_role_*"]
     actions  = ["delete"]
   }
 }

--- a/testdata/e2e/role-escalation-threshold/.tfclassify.hcl
+++ b/testdata/e2e/role-escalation-threshold/.tfclassify.hcl
@@ -8,7 +8,7 @@ classification "critical" {
   description = "Requires security review - high privilege escalation"
 
   rule {
-    resource = ["*_role_*", "*_security_group", "*_security_rule"]
+    resource = ["*_role_*"]
     actions  = ["delete"]
   }
 

--- a/testdata/e2e/role-exclusion/.tfclassify.hcl
+++ b/testdata/e2e/role-exclusion/.tfclassify.hcl
@@ -8,7 +8,7 @@ classification "critical" {
   description = "Requires security review"
 
   rule {
-    resource = ["*_role_*", "*_security_group", "*_security_rule"]
+    resource = ["*_role_*"]
     actions  = ["delete"]
   }
 

--- a/testdata/e2e/route-table/.tfclassify.hcl
+++ b/testdata/e2e/route-table/.tfclassify.hcl
@@ -2,7 +2,7 @@ classification "critical" {
   description = "Requires security review"
 
   rule {
-    resource = ["*_role_*", "*_security_group", "*_security_rule"]
+    resource = ["*_security_group", "*_security_rule"]
     actions  = ["delete"]
   }
 }


### PR DESCRIPTION
## Summary
- Removed irrelevant resource patterns from each e2e scenario's critical rule — each config now only references resources the scenario actually tests
- Enabled the azurerm plugin with `network_exposure {}` in `nsg-open-inbound`, giving the network-exposure analyzer its first e2e coverage

## Changes per scenario
| Scenario | Before | After |
|---|---|---|
| route-table | `*_role_*`, `*_security_group`, `*_security_rule` | `*_security_group`, `*_security_rule` |
| nsg-open-inbound | `*_role_*`, `*_security_group`, `*_security_rule` (no plugin) | `*_security_group`, `*_security_rule` + azurerm `network_exposure {}` |
| role-assignment-reader | `*_role_*`, `*_security_group`, `*_security_rule` | `*_role_*` |
| keyvault-destructive | `*_role_*`, `*_security_group`, `*_security_rule`, `*_key_vault*` | `*_key_vault*` |
| 7 role scenarios | `*_role_*`, `*_security_group`, `*_security_rule` | `*_role_*` |
| modules-pluginless | already clean | unchanged |

## Test plan
- [x] `make build && make test && make vet` — all pass locally
- [x] All 12 e2e scenarios pass in CI (run 22145016343)
- [x] `nsg-open-inbound` create phase now expects critical (exit 2) from plugin detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)