### PR TITLE
feat: add module-scoped rules, drift classification, and topology analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,8 @@ jobs:
           - cis-azure-foundations
           - blast-radius
           - evidence-signing
+          - module-scoped-rules
+          - topology
         include:
           # custom-role-cross-reference creates an azurerm_role_definition, which
           # requires Microsoft.Authorization/roleDefinitions/write — a permission

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ tfclassify classifies Terraform plan changes into organizational categories (cri
 
 **Layer 1 — Core Engine** (`internal/classify/`): Config-driven pattern matching. Glob patterns on resource types + actions, evaluated against precedence order from `.tfclassify.hcl`. This is the fast path — no plugins involved.
 
-**Layer 2 — Builtin Analyzers** (`internal/classify/deletion.go`, `replace.go`, `sensitive.go`, `blast_radius.go`): Cross-provider heuristics that run in-process. Implement `classify.BuiltinAnalyzer` interface. Detect deletions, destroy-and-recreate, sensitive attribute changes, and plan-wide blast radius thresholds.
+**Layer 2 — Builtin Analyzers** (`internal/classify/deletion.go`, `replace.go`, `sensitive.go`, `blast_radius.go`, `drift.go`, `topology.go`): Cross-provider heuristics that run in-process. Simple analyzers implement `classify.BuiltinAnalyzer` interface; plan-aware analyzers implement `classify.PlanAwareAnalyzer` (receives full `ParseResult`). Detect deletions, destroy-and-recreate, sensitive attribute changes, plan-wide blast radius thresholds, drift corrections, and dependency graph topology.
 
 **Layer 3 — External Plugins** (`sdk/` + `internal/plugin/`): Provider-specific deep inspection via gRPC (hashicorp/go-plugin). Plugins run as separate processes, communicate bidirectionally — host calls `PluginService.Analyze()`, plugin calls back `RunnerService.GetResourceChanges()` and `RunnerService.EmitDecision()`. The broker ID in `AnalyzeRequest` enables the plugin to dial back to the host's Runner server. Currently serves one deep analyzer (`privilege_escalation`) as the reference implementation.
 
@@ -94,6 +94,7 @@ The SDK and plugin have their own `go.mod`. The plugin uses a `replace` directiv
 - `sdk.Runner` — Host-side API exposed to plugins via gRPC. Methods: `GetResourceChanges`, `GetResourceChange`, `EmitDecision`.
 - `sdk.PluginSet` — Collection of analyzers provided by a plugin binary.
 - `classify.BuiltinAnalyzer` — In-process analyzer (Layer 2). Simpler interface: takes `[]plan.ResourceChange`, returns `[]ResourceDecision`.
+- `classify.PlanAwareAnalyzer` — In-process analyzer that receives the full `*plan.ParseResult` (for analyzers needing plan-level context like drift data or dependency graph).
 
 ## gRPC Protocol
 
@@ -105,7 +106,7 @@ Defined in `proto/tfclassify.proto`, generated code in `sdk/pb/`. Two services:
 
 ## Configuration
 
-HCL format (`.tfclassify.hcl`), parsed by `internal/config/` using `hashicorp/hcl/v2`. Key blocks: `classification` (rules with resource/not_resource glob + actions/not_actions, blast_radius thresholds), `plugin` (source, version, enabled, config), `precedence` list, `defaults`, `evidence` (artifact output with optional Ed25519 signing).
+HCL format (`.tfclassify.hcl`), parsed by `internal/config/` using `hashicorp/hcl/v2`. Key blocks: `classification` (rules with resource/not_resource glob + actions/not_actions + module/not_module, blast_radius thresholds, topology thresholds), `plugin` (source, version, enabled, config), `precedence` list, `defaults` (unclassified, no_changes, drift_classification), `evidence` (artifact output with optional Ed25519 signing).
 
 ## Plugin System
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Classify Terraform plan changes based on organization-defined rules. tfclassify 
   - [Precedence](#precedence)
   - [Defaults](#defaults)
   - [Blast Radius](#blast-radius)
+  - [Topology](#topology)
   - [Plugin Declarations](#plugin-declarations)
   - [Evidence](#evidence)
 - [Plan File Formats](#plan-file-formats)
@@ -338,6 +339,8 @@ classification "review" {
 | `not_resource` | list of globs | Resource type must match **none** of the patterns. Cannot combine with `resource` in the same rule. |
 | `actions` | list of strings | Terraform plan action. Omit to match all actions. See **Action Values** below. |
 | `not_actions` | list of strings | Inverse of `actions` — matches all actions EXCEPT those listed. Cannot combine with `actions` in the same rule. Same valid values as `actions`. |
+| `module` | list of globs | Module path must match at least one pattern. Uses `.` as separator (`*` matches one level, `**` any depth). Omit to match all modules. |
+| `not_module` | list of globs | Module path must match **none** of the patterns. Cannot combine with `module` in the same rule. |
 
 ### Action Values
 
@@ -373,6 +376,31 @@ Glob patterns use `*` to match any sequence of characters. Some useful patterns:
 | `*_key_vault_*` | `azurerm_key_vault_secret`, `azurerm_key_vault_key` | `azurerm_key_vault` |
 | `*` | Everything | — |
 
+### Module Filtering
+
+Rules can be scoped to specific Terraform modules using the `module` and `not_module` fields. These use glob patterns with `.` as the separator — `*` matches one module level, `**` matches any depth. An empty string matches the root module.
+
+```hcl
+# Only apply to resources inside module.production (any depth)
+classification "critical" {
+  rule {
+    module   = ["module.production", "module.production.**"]
+    resource = ["*"]
+    actions  = ["delete"]
+  }
+}
+
+# Apply to everything except production modules
+classification "standard" {
+  rule {
+    not_module = ["module.production", "module.production.**"]
+    resource   = ["*"]
+  }
+}
+```
+
+`module` and `not_module` are mutually exclusive — specifying both in the same rule is a validation error. Omitting both matches all modules including root (backward compatible).
+
 ### Precedence
 
 The `precedence` list controls two things:
@@ -391,13 +419,19 @@ The overall exit code is the highest across all resources. One critical resource
 
 ```hcl
 defaults {
-  unclassified   = "standard"   # Resources matching no rule
-  no_changes     = "auto"       # Plans with zero resource changes
-  plugin_timeout = "30s"        # Timeout for external plugin execution
+  unclassified         = "standard"   # Resources matching no rule
+  no_changes           = "auto"       # Plans with zero resource changes
+  drift_classification = "standard"   # Drift-corrected resources (optional)
+  plugin_timeout       = "30s"        # Timeout for external plugin execution
 }
 ```
 
-`unclassified` and `no_changes` must reference classification names from the precedence list. `plugin_timeout` accepts Go duration strings (e.g. `"10s"`, `"2m30s"`).
+| Field | Type | Description |
+|-------|------|-------------|
+| `unclassified` | string | Classification for resources matching no rule. Must reference a name in `precedence`. |
+| `no_changes` | string | Classification when the plan has zero resource changes. Must reference a name in `precedence`. |
+| `drift_classification` | string | Optional. Classification for resources whose changes are drift corrections (actual state diverged from config outside Terraform). Must reference a name in `precedence`. |
+| `plugin_timeout` | string | Timeout for external plugin execution. Go duration string (e.g. `"10s"`, `"2m30s"`). Default: `"30s"`. |
 
 ### Blast Radius
 
@@ -411,6 +445,7 @@ classification "critical" {
     max_deletions    = 5    # Standalone deletions (delete without create)
     max_replacements = 10   # Replacements (delete + create pairs)
     max_changes      = 50   # All resources with non-no-op actions
+    exclude_drift    = true  # Don't count drift corrections toward limits
   }
 }
 ```
@@ -420,8 +455,31 @@ classification "critical" {
 | `max_deletions` | int | Trigger when standalone deletions exceed this count |
 | `max_replacements` | int | Trigger when replacements (destroy + recreate) exceed this count |
 | `max_changes` | int | Trigger when total non-no-op changes exceed this count |
+| `exclude_drift` | bool | When `true`, drift-corrected resources are excluded from blast radius counts. Requires `drift_classification` in defaults. |
 
-All fields are optional. Omitted fields are not evaluated. Values must be positive integers. Multiple classifications can define different thresholds for graduated blast radius detection.
+All fields are optional. Omitted fields are not evaluated. Threshold values must be positive integers. Multiple classifications can define different thresholds for graduated blast radius detection.
+
+### Topology
+
+The optional `topology` block inside a classification uses the Terraform dependency graph to detect changes with high downstream impact. It builds a directed graph from the plan's configuration and computes each changed resource's downstream fan-out via BFS.
+
+```hcl
+classification "critical" {
+  description = "Requires security team approval"
+
+  topology {
+    max_downstream        = 10  # Flag if change affects 10+ downstream resources
+    max_propagation_depth = 3   # Flag if change cascades 3+ levels deep
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `max_downstream` | int | Trigger when a single resource's change propagates to more than N downstream resources |
+| `max_propagation_depth` | int | Trigger when a change cascades more than N levels deep in the dependency graph |
+
+All fields are optional. Omitted fields are not evaluated. Values must be positive integers. Multiple classifications can define different thresholds for graduated topology detection.
 
 ### Plugin Declarations
 
@@ -515,8 +573,13 @@ Cross-provider heuristics that run in-process after core rules. These detect Ter
 | `replace` | Resource replacements (destroy + recreate) |
 | `sensitive` | Changes to Terraform-marked sensitive attributes |
 | `blast_radius` | Plan-wide change counts exceeding configured thresholds |
+| `drift` | Resources whose changes are drift corrections (actual state diverged outside Terraform) |
+| `topology` | Resources whose changes propagate to many downstream dependents in the dependency graph |
 
-Builtin analyzers are always enabled and require no configuration, except `blast_radius` which requires a `blast_radius {}` block inside a classification (see [Blast Radius](#blast-radius)).
+Builtin analyzers are always enabled and require no configuration, except:
+- `blast_radius` requires a `blast_radius {}` block inside a classification (see [Blast Radius](#blast-radius))
+- `drift` requires `drift_classification` in the `defaults` block (see [Defaults](#defaults))
+- `topology` requires a `topology {}` block inside a classification (see [Topology](#topology))
 
 ### Layer 3: Deep Inspection Plugins
 
@@ -563,6 +626,8 @@ The [e2e test scenarios](testdata/e2e/) serve as a progressive learning path fro
 | Graduated thresholds | [role-escalation-threshold](testdata/e2e/role-escalation-threshold/) | Different action patterns per classification level |
 | Role exclusions | [role-exclusion](testdata/e2e/role-exclusion/) | `exclude` list bypasses plugin detection |
 | Module support | [modules-pluginless](testdata/e2e/modules-pluginless/) | Resources inside Terraform modules |
+| Module-scoped rules | [module-scoped-rules](testdata/e2e/module-scoped-rules/) | `module` field filters rules by module path |
+| Change topology | [topology](testdata/e2e/topology/) | Dependency graph fan-out thresholds |
 | CIS benchmark mapping | [cis-azure-foundations](testdata/e2e/cis-azure-foundations/) | Classifications named after CIS controls |
 
 ## E2E Test Scenarios
@@ -600,6 +665,13 @@ These scenarios demonstrate real-world classification behavior across all three 
 |----------|--------|---------------|
 | [modules-pluginless](testdata/e2e/modules-pluginless/) | Glob rules only, no plugins | Resources created inside Terraform modules are classified correctly. Module-expanded addresses (e.g., `module.network.azurerm_network_security_group.nsg`) match glob patterns on the resource type. |
 | [modules-plugin](testdata/e2e/modules-plugin/) | Plugin with `privilege_escalation` | Resources inside modules are passed to plugins for deep inspection. Module-expanded role assignments are analyzed for privilege escalation patterns. |
+| [module-scoped-rules](testdata/e2e/module-scoped-rules/) | `module = ["module.network"]` on critical | **Module-scoped rules.** Deletions inside `module.network` are classified as `critical`, while the same deletion at root level stays `standard`. Demonstrates the `module` field for per-module classification. |
+
+### Change Topology
+
+| Scenario | Config | What It Tests |
+|----------|--------|---------------|
+| [topology](testdata/e2e/topology/) | `topology { max_downstream = 1 }` on critical | **Dependency graph analysis.** VNet → Subnet → NSG Association chain. VNet has 2+ downstream dependents, exceeding `max_downstream = 1` threshold, triggering `critical`. |
 
 ### Compliance Benchmark Mapping
 
@@ -756,6 +828,6 @@ protoc --go_out=. --go-grpc_out=. proto/tfclassify.proto
 
 - **Sensitive attribute detection is top-level only.** The builtin `sensitive` analyzer detects changes to Terraform-marked sensitive attributes at the top level of a resource. Sensitive values nested inside objects or lists are not detected.
 
-- **Blast radius thresholds count all resources including no-ops.** The `max_changes` threshold in `blast_radius` applies to every resource with a non-no-op action. There is no way to scope thresholds to specific resource types or exclude certain actions from the count.
+- **Blast radius thresholds count all non-no-op resources.** The `max_changes` threshold in `blast_radius` applies to every resource with a non-no-op action. There is no way to scope thresholds to specific resource types. Use `exclude_drift = true` to exclude drift corrections from the count.
 
 - **Plugin analyzer errors are silently skipped.** If an external plugin analyzer returns an error during analysis, the error is logged but does not fail the classification run. This means plugin failures may produce incomplete results without an obvious indication in the output. Check verbose (`-v`) output or the explain command if you suspect a plugin is not producing expected decisions.

--- a/cmd/tfclassify/main.go
+++ b/cmd/tfclassify/main.go
@@ -30,13 +30,31 @@ var (
 )
 
 // builtinAnalyzers returns the default set of builtin analyzers.
-func builtinAnalyzers(cfg *config.Config) []classify.BuiltinAnalyzer {
+// planResult is used to provide drift data for blast radius drift exclusion.
+func builtinAnalyzers(cfg *config.Config, planResult *plan.ParseResult) []classify.BuiltinAnalyzer {
+	br := classify.NewBlastRadiusAnalyzer(cfg.Classifications)
+	br.SetDriftAddresses(classify.DriftAddresses(planResult))
 	return []classify.BuiltinAnalyzer{
 		&classify.DeletionAnalyzer{},
 		&classify.ReplaceAnalyzer{},
 		&classify.SensitiveAnalyzer{},
-		classify.NewBlastRadiusAnalyzer(cfg.Classifications),
+		br,
 	}
+}
+
+// planAwareAnalyzers returns the set of plan-aware analyzers.
+func planAwareAnalyzers(cfg *config.Config) []classify.PlanAwareAnalyzer {
+	var analyzers []classify.PlanAwareAnalyzer
+	if cfg.Defaults != nil && cfg.Defaults.DriftClassification != "" {
+		analyzers = append(analyzers, &classify.DriftAnalyzer{
+			DriftClassification: cfg.Defaults.DriftClassification,
+		})
+	}
+	topoAnalyzer := classify.NewTopologyAnalyzer(cfg.Classifications)
+	if len(topoAnalyzer.Thresholds()) > 0 {
+		analyzers = append(analyzers, topoAnalyzer)
+	}
+	return analyzers
 }
 
 func main() {
@@ -155,7 +173,7 @@ func run(cmd *cobra.Command, args []string) error {
 	result := classifier.Classify(planResult.Changes)
 
 	// Run builtin analyzers (deletion, replace, sensitive detection)
-	classifier.RunBuiltinAnalyzers(result, planResult.Changes, builtinAnalyzers(cfg))
+	classifier.RunBuiltinAnalyzers(result, planResult, builtinAnalyzers(cfg, planResult), planAwareAnalyzers(cfg))
 
 	// Run external plugins (if any configured)
 	if hasExternalPlugins(cfg) {
@@ -242,7 +260,7 @@ func generateEvidence(cfg *config.Config, result *classify.Result, planResult *p
 	var explainResult *classify.ExplainResult
 	if opts.IncludeTrace {
 		explainResult = classifier.ExplainClassify(planResult.Changes)
-		classifier.AddExplainBuiltinAnalyzers(explainResult, planResult.Changes, builtinAnalyzers(cfg))
+		classifier.AddExplainBuiltinAnalyzers(explainResult, planResult, builtinAnalyzers(cfg, planResult), planAwareAnalyzers(cfg))
 		classifier.FinalizeExplanation(explainResult)
 	}
 
@@ -312,7 +330,7 @@ func runExplain(cmd *cobra.Command, args []string) error {
 	result := classifier.ExplainClassify(planResult.Changes)
 
 	// Run builtin analyzers with trace collection
-	builtinDecisions := classifier.AddExplainBuiltinAnalyzers(result, planResult.Changes, builtinAnalyzers(cfg))
+	builtinDecisions := classifier.AddExplainBuiltinAnalyzers(result, planResult, builtinAnalyzers(cfg, planResult), planAwareAnalyzers(cfg))
 
 	// Run external plugins (if any configured)
 	if hasExternalPlugins(cfg) {

--- a/docs/examples/full-reference/.tfclassify.hcl
+++ b/docs/examples/full-reference/.tfclassify.hcl
@@ -102,6 +102,19 @@ classification "critical" {
     # No "actions" field — matches create, update, delete, read, and no-op.
   }
 
+  # Rule 4: Deletions inside production modules.
+  # The "module" field filters by Terraform module path. Uses glob patterns
+  # with "." as the separator — "*" matches one module level, "**" any depth.
+  # Omitting "module" (and "not_module") matches all modules including root.
+  rule {
+    description = "Production module deletions require security review"
+    module      = ["module.production", "module.production.**"]
+    resource    = ["*"]
+    actions     = ["delete"]
+    # "module" restricts this rule to resources inside the named modules.
+    # Cannot combine "module" and "not_module" in the same rule.
+  }
+
   # Blast radius thresholds — triggers when plan-wide counts exceed limits.
   # When any threshold is exceeded, ALL resources in the plan receive a
   # decision at this classification level. Omitted fields are not evaluated.
@@ -109,6 +122,16 @@ classification "critical" {
     max_deletions    = 5    # Standalone deletions (delete without create)
     max_replacements = 10   # Replacements (delete + create)
     max_changes      = 50   # All resources with non-no-op actions
+    exclude_drift    = true  # Don't count drift-corrected resources toward limits
+  }
+
+  # Topology thresholds — triggers when a single resource's change propagates
+  # to too many downstream resources in the Terraform dependency graph.
+  # Uses the plan's configuration block to build a directed dependency graph
+  # and computes fan-out via BFS from each changed resource.
+  topology {
+    max_downstream        = 10  # Flag if change affects 10+ downstream resources
+    max_propagation_depth = 3   # Flag if change cascades 3+ levels deep
   }
 
   # Plugin-specific analyzer configuration for this classification level.
@@ -186,10 +209,25 @@ classification "high" {
     resource    = ["*_dns_*"]
   }
 
+  # Rule 5: Deletions outside production modules.
+  # "not_module" is the inverse of "module" — matches resources NOT in
+  # the listed modules. Cannot combine with "module" in the same rule.
+  # rule {
+  #   description = "Non-production deletions need team lead review"
+  #   not_module  = ["module.production", "module.production.**"]
+  #   resource    = ["*"]
+  #   actions     = ["delete"]
+  # }
+
   # Less strict blast radius for "high" — catches medium-scale changes.
   blast_radius {
     max_deletions = 2
     max_changes   = 20
+  }
+
+  # Less strict topology thresholds for "high".
+  topology {
+    max_downstream = 20
   }
 
   # Plugin analyzer configuration for "high" — catch roles with write access
@@ -281,6 +319,13 @@ defaults {
   # Always produces exit code 0 regardless of the classification's position
   # in the precedence list.
   no_changes = "auto"
+
+  # Classification for drift-corrected resources. When set, resources that
+  # Terraform plans to change because their actual state has drifted from the
+  # desired configuration receive this classification. This separates intentional
+  # changes from drift corrections in your approval workflow.
+  # Omit to not apply drift-based classification.
+  drift_classification = "standard"
 
   # Timeout for external plugin execution. Parsed as a Go duration string
   # (e.g., "10s", "2m30s", "500ms"). If omitted or invalid, defaults to 30s.

--- a/docs/examples/full-reference/README.md
+++ b/docs/examples/full-reference/README.md
@@ -10,12 +10,16 @@ See [`.tfclassify.hcl`](.tfclassify.hcl) for the fully annotated configuration f
 |---------|-------|
 | Plugin declaration (enabled + disabled) | `plugin "azurerm"`, `plugin "aws"` |
 | Classification-scoped plugin config | `azurerm { privilege_escalation { ... } }` inside classification blocks |
-| Multiple rules per classification | `classification "critical"` has 3 rules |
+| Multiple rules per classification | `classification "critical"` has 4 rules |
 | Rule descriptions | `description = "..."` on each rule block |
 | Action filtering | `actions = ["delete"]` on critical rules |
+| Module-scoped rules | `module = ["module.production", ...]` on critical rule 4 |
 | `not_resource` exclusion | `classification "standard"` uses `not_resource` |
 | Glob precision (`*_key_vault` vs `*_key_vault_*`) | Rules 2-3 in critical/high |
 | Five-level precedence with exit codes | `precedence = ["critical", "high", "standard", "low", "auto"]` |
+| Blast radius with drift exclusion | `blast_radius { exclude_drift = true }` in critical |
+| Change topology thresholds | `topology { max_downstream = 10 }` in critical and high |
+| Drift classification | `defaults { drift_classification = "standard" }` |
 | `plugin_timeout` default | `defaults { plugin_timeout = "30s" }` |
 
 ## Terraform Plan
@@ -87,8 +91,12 @@ Exit code **4** corresponds to `critical` in a five-level precedence list (auto=
 | Five precedence levels | `critical` → `high` → `standard` → `low` → `auto` with exit codes 4-0 |
 | Rule descriptions in output | Custom descriptions appear instead of auto-generated ones |
 | Glob precision | `*_key_vault` matches the vault itself; `*_key_vault_*` matches children only |
+| Module-scoped rules | `module = ["module.production", ...]` targets specific Terraform modules |
 | `not_resource` | Standard catches everything except monitoring resources |
 | `actions` filtering | Same resource type can be critical (delete) vs high (create/update) |
 | No-op classification | Resources with no changes classified as auto (exit code 0) |
 | Plugin configuration | Classification-scoped plugin config with graduated thresholds |
 | Sensitive attributes | `db_password` has `after_sensitive.value = true` (detected by builtin analyzer) |
+| Drift classification | `drift_classification = "standard"` separates drift from intentional changes |
+| Blast radius drift exclusion | `exclude_drift = true` ignores drift corrections in blast radius counts |
+| Topology thresholds | `topology { max_downstream = 10 }` detects high-impact dependency chains |

--- a/internal/classify/analyzer.go
+++ b/internal/classify/analyzer.go
@@ -15,12 +15,25 @@ type BuiltinAnalyzer interface {
 	Analyze(changes []plan.ResourceChange) []ResourceDecision
 }
 
-// RunBuiltinAnalyzers runs all registered builtin analyzers against the given
-// changes and merges their decisions into the result using precedence rules.
-func (c *Classifier) RunBuiltinAnalyzers(result *Result, changes []plan.ResourceChange, analyzers []BuiltinAnalyzer) {
+// PlanAwareAnalyzer is like BuiltinAnalyzer but receives the full ParseResult
+// for analyzers that need plan-level context (drift, topology).
+type PlanAwareAnalyzer interface {
+	// Name returns the analyzer's identifier.
+	Name() string
+	// AnalyzePlan inspects the full parse result and returns decisions.
+	AnalyzePlan(result *plan.ParseResult) []ResourceDecision
+}
+
+// RunBuiltinAnalyzers runs all registered builtin analyzers and plan-aware analyzers
+// against the given plan result and merges their decisions into the result using precedence rules.
+func (c *Classifier) RunBuiltinAnalyzers(result *Result, planResult *plan.ParseResult, analyzers []BuiltinAnalyzer, planAnalyzers []PlanAwareAnalyzer) {
 	var allDecisions []ResourceDecision
 	for _, a := range analyzers {
-		decisions := a.Analyze(changes)
+		decisions := a.Analyze(planResult.Changes)
+		allDecisions = append(allDecisions, decisions...)
+	}
+	for _, a := range planAnalyzers {
+		decisions := a.AnalyzePlan(planResult)
 		allDecisions = append(allDecisions, decisions...)
 	}
 	if len(allDecisions) > 0 {

--- a/internal/classify/analyzer_test.go
+++ b/internal/classify/analyzer_test.go
@@ -15,6 +15,11 @@ func defaultAnalyzers() []BuiltinAnalyzer {
 	}
 }
 
+// planResultFromChanges creates a minimal ParseResult wrapping changes.
+func planResultFromChanges(changes []plan.ResourceChange) *plan.ParseResult {
+	return &plan.ParseResult{Changes: changes}
+}
+
 func TestRunBuiltinAnalyzers_Integration(t *testing.T) {
 	cfg := &config.Config{
 		Classifications: []config.ClassificationConfig{
@@ -55,7 +60,7 @@ func TestRunBuiltinAnalyzers_Integration(t *testing.T) {
 	}
 
 	// Run builtin analyzers
-	classifier.RunBuiltinAnalyzers(result, changes, defaultAnalyzers())
+	classifier.RunBuiltinAnalyzers(result, planResultFromChanges(changes), defaultAnalyzers(), nil)
 
 	// Analyzers emit empty classification => maps to "standard" (unclassified default)
 	// So results remain standard (no upgrade)
@@ -90,7 +95,7 @@ func TestRunBuiltinAnalyzers_MergePrecedence(t *testing.T) {
 	}
 
 	// Builtin analyzers emit empty classification => maps to defaults.unclassified = "critical"
-	classifier.RunBuiltinAnalyzers(result, changes, defaultAnalyzers())
+	classifier.RunBuiltinAnalyzers(result, planResultFromChanges(changes), defaultAnalyzers(), nil)
 
 	if result.ResourceDecisions[0].Classification != "critical" {
 		t.Errorf("expected 'critical' after builtin analyzer merge, got %q", result.ResourceDecisions[0].Classification)
@@ -116,7 +121,7 @@ func TestRunBuiltinAnalyzers_NoChanges(t *testing.T) {
 
 	result := classifier.Classify([]plan.ResourceChange{})
 
-	classifier.RunBuiltinAnalyzers(result, []plan.ResourceChange{}, defaultAnalyzers())
+	classifier.RunBuiltinAnalyzers(result, planResultFromChanges(nil), defaultAnalyzers(), nil)
 
 	if !result.NoChanges {
 		t.Error("expected NoChanges to remain true")
@@ -146,7 +151,7 @@ func TestRunBuiltinAnalyzers_NoTriggers(t *testing.T) {
 	initialDecisions := make([]ResourceDecision, len(result.ResourceDecisions))
 	copy(initialDecisions, result.ResourceDecisions)
 
-	classifier.RunBuiltinAnalyzers(result, changes, defaultAnalyzers())
+	classifier.RunBuiltinAnalyzers(result, planResultFromChanges(changes), defaultAnalyzers(), nil)
 
 	for i, d := range result.ResourceDecisions {
 		if d.Classification != initialDecisions[i].Classification {
@@ -176,7 +181,7 @@ func TestRunBuiltinAnalyzers_NilAnalyzers(t *testing.T) {
 
 	result := classifier.Classify(changes)
 
-	classifier.RunBuiltinAnalyzers(result, changes, nil)
+	classifier.RunBuiltinAnalyzers(result, planResultFromChanges(changes), nil, nil)
 
 	if result.ResourceDecisions[0].Classification != "standard" {
 		t.Errorf("expected classification unchanged, got %q", result.ResourceDecisions[0].Classification)
@@ -214,7 +219,7 @@ func TestRunBuiltinAnalyzers_AllThreeAnalyzersTrigger(t *testing.T) {
 	}
 
 	result := classifier.Classify(changes)
-	classifier.RunBuiltinAnalyzers(result, changes, defaultAnalyzers())
+	classifier.RunBuiltinAnalyzers(result, planResultFromChanges(changes), defaultAnalyzers(), nil)
 
 	if len(result.ResourceDecisions) != 4 {
 		t.Fatalf("expected 4 decisions, got %d", len(result.ResourceDecisions))

--- a/internal/classify/blast_radius.go
+++ b/internal/classify/blast_radius.go
@@ -14,6 +14,9 @@ import (
 type BlastRadiusAnalyzer struct {
 	// thresholds maps classification name to its blast radius config.
 	thresholds map[string]*config.BlastRadiusConfig
+	// driftAddresses is the set of resource addresses that are drift corrections.
+	// When exclude_drift is enabled for a threshold, these addresses are excluded from counts.
+	driftAddresses map[string]struct{}
 }
 
 // NewBlastRadiusAnalyzer creates a BlastRadiusAnalyzer from the classification configs.
@@ -25,6 +28,11 @@ func NewBlastRadiusAnalyzer(classifications []config.ClassificationConfig) *Blas
 		}
 	}
 	return &BlastRadiusAnalyzer{thresholds: thresholds}
+}
+
+// SetDriftAddresses provides the set of drift addresses for exclude_drift support.
+func (a *BlastRadiusAnalyzer) SetDriftAddresses(addrs map[string]struct{}) {
+	a.driftAddresses = addrs
 }
 
 // Name returns the analyzer name.
@@ -40,38 +48,7 @@ func (a *BlastRadiusAnalyzer) Analyze(changes []plan.ResourceChange) []ResourceD
 		return nil
 	}
 
-	// Single pass to count actions
-	var deletions, replacements, totalChanges int
-	for _, change := range changes {
-		hasDelete := false
-		hasCreate := false
-		hasNonNoOp := false
-
-		for _, action := range change.Actions {
-			if action == "delete" {
-				hasDelete = true
-			}
-			if action == "create" {
-				hasCreate = true
-			}
-			if action != "no-op" {
-				hasNonNoOp = true
-			}
-		}
-
-		if hasDelete && !hasCreate {
-			deletions++
-		}
-		if hasDelete && hasCreate {
-			replacements++
-		}
-		if hasNonNoOp {
-			totalChanges++
-		}
-	}
-
 	// Check each classification's thresholds and collect decisions per classification
-	// We use a map to accumulate multiple reasons per classification
 	type classDecision struct {
 		classification string
 		reasons        []string
@@ -79,6 +56,42 @@ func (a *BlastRadiusAnalyzer) Analyze(changes []plan.ResourceChange) []ResourceD
 	var triggered []classDecision
 
 	for classificationName, br := range a.thresholds {
+		excludeDrift := br.ExcludeDrift != nil && *br.ExcludeDrift
+
+		// Single pass to count actions (per threshold, since exclude_drift may differ)
+		var deletions, replacements, totalChanges int
+		for _, change := range changes {
+			if excludeDrift && a.isDrift(change.Address) {
+				continue
+			}
+
+			hasDelete := false
+			hasCreate := false
+			hasNonNoOp := false
+
+			for _, action := range change.Actions {
+				if action == "delete" {
+					hasDelete = true
+				}
+				if action == "create" {
+					hasCreate = true
+				}
+				if action != "no-op" {
+					hasNonNoOp = true
+				}
+			}
+
+			if hasDelete && !hasCreate {
+				deletions++
+			}
+			if hasDelete && hasCreate {
+				replacements++
+			}
+			if hasNonNoOp {
+				totalChanges++
+			}
+		}
+
 		var reasons []string
 		if br.MaxDeletions != nil && deletions > *br.MaxDeletions {
 			reasons = append(reasons, fmt.Sprintf(
@@ -128,6 +141,15 @@ func (a *BlastRadiusAnalyzer) Analyze(changes []plan.ResourceChange) []ResourceD
 	}
 
 	return decisions
+}
+
+// isDrift returns true if the address is a drift-corrected resource.
+func (a *BlastRadiusAnalyzer) isDrift(address string) bool {
+	if a.driftAddresses == nil {
+		return false
+	}
+	_, ok := a.driftAddresses[address]
+	return ok
 }
 
 // isNoOp returns true if the resource's actions consist only of "no-op".

--- a/internal/classify/classifier.go
+++ b/internal/classify/classifier.go
@@ -89,7 +89,7 @@ func (c *Classifier) classifyResource(change plan.ResourceChange) ResourceDecisi
 		rules := c.matchers[classificationName]
 
 		for _, rule := range rules {
-			if rule.matchesResource(change.Type) && rule.matchesActions(change.Actions) {
+			if rule.matchesResource(change.Type) && rule.matchesActions(change.Actions) && rule.matchesModule(change.ModuleAddress) {
 				decision.Classification = classificationName
 				decision.ClassificationDescription = rule.classificationDescription
 				decision.MatchedRules = []string{rule.ruleDescription}
@@ -173,8 +173,9 @@ func (c *Classifier) explainResource(change plan.ResourceChange) ResourceExplana
 
 			resourceMatch := rule.matchesResource(change.Type)
 			actionMatch := rule.matchesActions(change.Actions)
+			moduleMatch := rule.matchesModule(change.ModuleAddress)
 
-			if resourceMatch && actionMatch {
+			if resourceMatch && actionMatch && moduleMatch {
 				entry.Result = TraceMatch
 				if len(rule.actions) == 0 {
 					entry.Reason = "catch-all"
@@ -189,6 +190,8 @@ func (c *Classifier) explainResource(change plan.ResourceChange) ResourceExplana
 				entry.Result = TraceSkip
 				if !resourceMatch {
 					entry.Reason = "resource mismatch"
+				} else if !moduleMatch {
+					entry.Reason = "module mismatch"
 				} else {
 					entry.Reason = formatActionMismatch(change.Actions, rule.actions)
 				}
@@ -222,22 +225,17 @@ func formatActionMismatch(changeActions []string, ruleActions map[string]struct{
 	return fmt.Sprintf("action mismatch: %v not in %v", changeActions, ruleList)
 }
 
-// AddExplainBuiltinAnalyzers runs builtin analyzers and adds their results to the
-// explanation trace. Returns decisions for precedence merging.
-func (c *Classifier) AddExplainBuiltinAnalyzers(result *ExplainResult, changes []plan.ResourceChange, analyzers []BuiltinAnalyzer) []ResourceDecision {
+// AddExplainBuiltinAnalyzers runs builtin analyzers and plan-aware analyzers, adding
+// their results to the explanation trace. Returns decisions for precedence merging.
+func (c *Classifier) AddExplainBuiltinAnalyzers(result *ExplainResult, planResult *plan.ParseResult, analyzers []BuiltinAnalyzer, planAnalyzers []PlanAwareAnalyzer) []ResourceDecision {
 	// Build a lookup of explanations by address
 	explanationMap := make(map[string]*ResourceExplanation)
 	for i := range result.Resources {
 		explanationMap[result.Resources[i].Address] = &result.Resources[i]
 	}
 
-	var allDecisions []ResourceDecision
-	for _, analyzer := range analyzers {
-		decisions := analyzer.Analyze(changes)
+	addDecisionsToTrace := func(analyzerName string, decisions []ResourceDecision) {
 		for _, decision := range decisions {
-			allDecisions = append(allDecisions, decision)
-
-			// Resolve empty classification to default (same as AddPluginDecisions)
 			classification := decision.Classification
 			if classification == "" {
 				classification = c.config.Defaults.Unclassified
@@ -250,8 +248,8 @@ func (c *Classifier) AddExplainBuiltinAnalyzers(result *ExplainResult, changes [
 
 			entry := TraceEntry{
 				Classification: classification,
-				Source:         "builtin: " + analyzer.Name(),
-				Rule:           analyzer.Name(),
+				Source:         "builtin: " + analyzerName,
+				Rule:           analyzerName,
 				Result:         TraceMatch,
 				Reason:         reason,
 			}
@@ -260,6 +258,18 @@ func (c *Classifier) AddExplainBuiltinAnalyzers(result *ExplainResult, changes [
 				exp.Trace = append(exp.Trace, entry)
 			}
 		}
+	}
+
+	var allDecisions []ResourceDecision
+	for _, analyzer := range analyzers {
+		decisions := analyzer.Analyze(planResult.Changes)
+		allDecisions = append(allDecisions, decisions...)
+		addDecisionsToTrace(analyzer.Name(), decisions)
+	}
+	for _, analyzer := range planAnalyzers {
+		decisions := analyzer.AnalyzePlan(planResult)
+		allDecisions = append(allDecisions, decisions...)
+		addDecisionsToTrace(analyzer.Name(), decisions)
 	}
 
 	return allDecisions

--- a/internal/classify/classifier_test.go
+++ b/internal/classify/classifier_test.go
@@ -590,9 +590,9 @@ func TestExplainClassify_BuiltinAnalyzerTrace(t *testing.T) {
 	}
 
 	result := classifier.ExplainClassify(changes)
-	builtinDecisions := classifier.AddExplainBuiltinAnalyzers(result, changes, []BuiltinAnalyzer{
+	builtinDecisions := classifier.AddExplainBuiltinAnalyzers(result, planResultFromChanges(changes), []BuiltinAnalyzer{
 		&DeletionAnalyzer{},
-	})
+	}, nil)
 
 	if len(builtinDecisions) != 1 {
 		t.Fatalf("expected 1 builtin decision, got %d", len(builtinDecisions))
@@ -706,6 +706,203 @@ func TestClassify_PluginDecisionsWithUnknownClassification(t *testing.T) {
 	if result.ResourceDecisions[0].Classification != "standard" {
 		t.Errorf("expected resource to remain 'standard' when unknown classification is ignored, got '%s'",
 			result.ResourceDecisions[0].Classification)
+	}
+}
+
+func TestClassify_ModuleScopedRules(t *testing.T) {
+	cfg := &config.Config{
+		Classifications: []config.ClassificationConfig{
+			{
+				Name:        "critical",
+				Description: "Critical",
+				Rules: []config.RuleConfig{
+					{Resource: []string{"*"}, Actions: []string{"delete"}, Module: []string{"module.production", "module.production.**"}},
+				},
+			},
+			{
+				Name:        "standard",
+				Description: "Standard",
+				Rules: []config.RuleConfig{
+					{Resource: []string{"*"}},
+				},
+			},
+		},
+		Precedence: []string{"critical", "standard"},
+		Defaults: &config.DefaultsConfig{
+			Unclassified: "standard",
+			NoChanges:    "standard",
+		},
+	}
+
+	classifier, err := New(cfg)
+	if err != nil {
+		t.Fatalf("failed to create classifier: %v", err)
+	}
+
+	tests := []struct {
+		name          string
+		moduleAddress string
+		actions       []string
+		wantClass     string
+	}{
+		{
+			name:          "delete in production module → critical",
+			moduleAddress: "module.production",
+			actions:       []string{"delete"},
+			wantClass:     "critical",
+		},
+		{
+			name:          "delete in production submodule → critical",
+			moduleAddress: "module.production.module.network",
+			actions:       []string{"delete"},
+			wantClass:     "critical",
+		},
+		{
+			name:          "delete in staging module → standard (no module match)",
+			moduleAddress: "module.staging",
+			actions:       []string{"delete"},
+			wantClass:     "standard",
+		},
+		{
+			name:          "delete in root module → standard (no module match)",
+			moduleAddress: "",
+			actions:       []string{"delete"},
+			wantClass:     "standard",
+		},
+		{
+			name:          "create in production module → standard (no action match)",
+			moduleAddress: "module.production",
+			actions:       []string{"create"},
+			wantClass:     "standard",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			changes := []plan.ResourceChange{
+				{
+					Address:       "azurerm_resource_group.test",
+					Type:          "azurerm_resource_group",
+					Actions:       tt.actions,
+					ModuleAddress: tt.moduleAddress,
+				},
+			}
+
+			result := classifier.Classify(changes)
+
+			if result.ResourceDecisions[0].Classification != tt.wantClass {
+				t.Errorf("expected classification %q, got %q",
+					tt.wantClass, result.ResourceDecisions[0].Classification)
+			}
+		})
+	}
+}
+
+func TestClassify_NotModuleRules(t *testing.T) {
+	cfg := &config.Config{
+		Classifications: []config.ClassificationConfig{
+			{
+				Name:        "critical",
+				Description: "Critical",
+				Rules: []config.RuleConfig{
+					{Resource: []string{"*"}, Actions: []string{"delete"}, NotModule: []string{"module.staging", "module.staging.**"}},
+				},
+			},
+			{
+				Name:        "standard",
+				Description: "Standard",
+				Rules: []config.RuleConfig{
+					{Resource: []string{"*"}},
+				},
+			},
+		},
+		Precedence: []string{"critical", "standard"},
+		Defaults: &config.DefaultsConfig{
+			Unclassified: "standard",
+			NoChanges:    "standard",
+		},
+	}
+
+	classifier, err := New(cfg)
+	if err != nil {
+		t.Fatalf("failed to create classifier: %v", err)
+	}
+
+	tests := []struct {
+		name          string
+		moduleAddress string
+		wantClass     string
+	}{
+		{"delete in production → critical", "module.production", "critical"},
+		{"delete in root → critical", "", "critical"},
+		{"delete in staging → standard (excluded)", "module.staging", "standard"},
+		{"delete in staging submodule → standard (excluded)", "module.staging.module.db", "standard"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			changes := []plan.ResourceChange{
+				{
+					Address:       "azurerm_resource_group.test",
+					Type:          "azurerm_resource_group",
+					Actions:       []string{"delete"},
+					ModuleAddress: tt.moduleAddress,
+				},
+			}
+
+			result := classifier.Classify(changes)
+
+			if result.ResourceDecisions[0].Classification != tt.wantClass {
+				t.Errorf("expected classification %q, got %q",
+					tt.wantClass, result.ResourceDecisions[0].Classification)
+			}
+		})
+	}
+}
+
+func TestExplainClassify_ModuleMismatchReason(t *testing.T) {
+	cfg := &config.Config{
+		Classifications: []config.ClassificationConfig{
+			{
+				Name: "critical",
+				Rules: []config.RuleConfig{
+					{Resource: []string{"*"}, Module: []string{"module.production"}},
+				},
+			},
+			{
+				Name: "standard",
+				Rules: []config.RuleConfig{
+					{Resource: []string{"*"}},
+				},
+			},
+		},
+		Precedence: []string{"critical", "standard"},
+		Defaults: &config.DefaultsConfig{
+			Unclassified: "standard",
+			NoChanges:    "standard",
+		},
+	}
+
+	classifier, err := New(cfg)
+	if err != nil {
+		t.Fatalf("failed to create classifier: %v", err)
+	}
+
+	changes := []plan.ResourceChange{
+		{
+			Address:       "azurerm_resource_group.test",
+			Type:          "azurerm_resource_group",
+			Actions:       []string{"delete"},
+			ModuleAddress: "module.staging",
+		},
+	}
+
+	result := classifier.ExplainClassify(changes)
+	res := result.Resources[0]
+
+	// The critical rule should show "module mismatch"
+	if res.Trace[0].Reason != "module mismatch" {
+		t.Errorf("expected 'module mismatch' reason for critical rule, got %q", res.Trace[0].Reason)
 	}
 }
 

--- a/internal/classify/drift.go
+++ b/internal/classify/drift.go
@@ -1,0 +1,66 @@
+package classify
+
+import (
+	"fmt"
+
+	"github.com/jokarl/tfclassify/internal/plan"
+)
+
+// DriftAnalyzer detects resources whose changes are drift corrections
+// (changed outside Terraform) and classifies them at the configured drift level.
+type DriftAnalyzer struct {
+	// DriftClassification is the classification to assign to drift-corrected resources.
+	// If empty, the analyzer produces no decisions.
+	DriftClassification string
+}
+
+// Name returns the analyzer name.
+func (a *DriftAnalyzer) Name() string {
+	return "drift"
+}
+
+// AnalyzePlan checks which resources in the plan overlap with drift entries.
+func (a *DriftAnalyzer) AnalyzePlan(result *plan.ParseResult) []ResourceDecision {
+	if a.DriftClassification == "" {
+		return nil
+	}
+	if len(result.DriftChanges) == 0 {
+		return nil
+	}
+
+	// Build set of addresses that appear in resource_drift
+	driftAddresses := make(map[string]struct{}, len(result.DriftChanges))
+	for _, dc := range result.DriftChanges {
+		driftAddresses[dc.Address] = struct{}{}
+	}
+
+	var decisions []ResourceDecision
+	for _, change := range result.Changes {
+		if _, isDrift := driftAddresses[change.Address]; isDrift {
+			decisions = append(decisions, ResourceDecision{
+				Address:        change.Address,
+				ResourceType:   change.Type,
+				Actions:        change.Actions,
+				Classification: a.DriftClassification,
+				MatchedRules: []string{
+					fmt.Sprintf("builtin: drift - Resource %s is a drift correction (changed outside Terraform)", change.Address),
+				},
+			})
+		}
+	}
+
+	return decisions
+}
+
+// DriftAddresses returns the set of resource addresses that appear in drift changes.
+// This is used by BlastRadiusAnalyzer to exclude drift resources from counts.
+func DriftAddresses(planResult *plan.ParseResult) map[string]struct{} {
+	if planResult == nil || len(planResult.DriftChanges) == 0 {
+		return nil
+	}
+	addrs := make(map[string]struct{}, len(planResult.DriftChanges))
+	for _, dc := range planResult.DriftChanges {
+		addrs[dc.Address] = struct{}{}
+	}
+	return addrs
+}

--- a/internal/classify/drift_test.go
+++ b/internal/classify/drift_test.go
@@ -1,0 +1,241 @@
+package classify
+
+import (
+	"testing"
+
+	"github.com/jokarl/tfclassify/internal/config"
+	"github.com/jokarl/tfclassify/internal/plan"
+)
+
+func TestDriftAnalyzer_NoDriftClassification(t *testing.T) {
+	a := &DriftAnalyzer{DriftClassification: ""}
+	result := &plan.ParseResult{
+		Changes:      []plan.ResourceChange{{Address: "a.b", Type: "a", Actions: []string{"update"}}},
+		DriftChanges: []plan.ResourceChange{{Address: "a.b", Type: "a", Actions: []string{"update"}}},
+	}
+	decisions := a.AnalyzePlan(result)
+	if len(decisions) != 0 {
+		t.Errorf("expected no decisions when drift_classification is empty, got %d", len(decisions))
+	}
+}
+
+func TestDriftAnalyzer_NoDriftChanges(t *testing.T) {
+	a := &DriftAnalyzer{DriftClassification: "standard"}
+	result := &plan.ParseResult{
+		Changes:      []plan.ResourceChange{{Address: "a.b", Type: "a", Actions: []string{"update"}}},
+		DriftChanges: nil,
+	}
+	decisions := a.AnalyzePlan(result)
+	if len(decisions) != 0 {
+		t.Errorf("expected no decisions when no drift, got %d", len(decisions))
+	}
+}
+
+func TestDriftAnalyzer_DriftOnly(t *testing.T) {
+	a := &DriftAnalyzer{DriftClassification: "standard"}
+	result := &plan.ParseResult{
+		Changes: []plan.ResourceChange{
+			{Address: "azurerm_resource_group.main", Type: "azurerm_resource_group", Actions: []string{"update"}},
+		},
+		DriftChanges: []plan.ResourceChange{
+			{Address: "azurerm_resource_group.main", Type: "azurerm_resource_group", Actions: []string{"update"}},
+		},
+	}
+
+	decisions := a.AnalyzePlan(result)
+	if len(decisions) != 1 {
+		t.Fatalf("expected 1 decision, got %d", len(decisions))
+	}
+	if decisions[0].Classification != "standard" {
+		t.Errorf("expected classification 'standard', got %q", decisions[0].Classification)
+	}
+	if decisions[0].Address != "azurerm_resource_group.main" {
+		t.Errorf("expected address azurerm_resource_group.main, got %q", decisions[0].Address)
+	}
+}
+
+func TestDriftAnalyzer_MixedDriftAndIntent(t *testing.T) {
+	a := &DriftAnalyzer{DriftClassification: "standard"}
+	result := &plan.ParseResult{
+		Changes: []plan.ResourceChange{
+			{Address: "azurerm_resource_group.main", Type: "azurerm_resource_group", Actions: []string{"update"}},
+			{Address: "azurerm_virtual_network.main", Type: "azurerm_virtual_network", Actions: []string{"create"}},
+		},
+		DriftChanges: []plan.ResourceChange{
+			{Address: "azurerm_resource_group.main", Type: "azurerm_resource_group", Actions: []string{"update"}},
+		},
+	}
+
+	decisions := a.AnalyzePlan(result)
+	if len(decisions) != 1 {
+		t.Fatalf("expected 1 decision (only drift resource), got %d", len(decisions))
+	}
+	if decisions[0].Address != "azurerm_resource_group.main" {
+		t.Errorf("expected drift decision for azurerm_resource_group.main, got %q", decisions[0].Address)
+	}
+}
+
+func TestDriftAnalyzer_Name(t *testing.T) {
+	a := &DriftAnalyzer{}
+	if a.Name() != "drift" {
+		t.Errorf("expected name 'drift', got %q", a.Name())
+	}
+}
+
+func TestDriftAddresses_NilPlanResult(t *testing.T) {
+	addrs := DriftAddresses(nil)
+	if addrs != nil {
+		t.Errorf("expected nil for nil plan result, got %v", addrs)
+	}
+}
+
+func TestDriftAddresses_NoDrift(t *testing.T) {
+	addrs := DriftAddresses(&plan.ParseResult{})
+	if addrs != nil {
+		t.Errorf("expected nil for no drift, got %v", addrs)
+	}
+}
+
+func TestDriftAddresses_WithDrift(t *testing.T) {
+	result := &plan.ParseResult{
+		DriftChanges: []plan.ResourceChange{
+			{Address: "a.b"},
+			{Address: "c.d"},
+		},
+	}
+	addrs := DriftAddresses(result)
+	if len(addrs) != 2 {
+		t.Fatalf("expected 2 drift addresses, got %d", len(addrs))
+	}
+	if _, ok := addrs["a.b"]; !ok {
+		t.Error("expected a.b in drift addresses")
+	}
+	if _, ok := addrs["c.d"]; !ok {
+		t.Error("expected c.d in drift addresses")
+	}
+}
+
+func TestBlastRadius_ExcludeDrift(t *testing.T) {
+	maxDel := 1
+	excludeTrue := true
+	a := NewBlastRadiusAnalyzer([]config.ClassificationConfig{
+		{
+			Name: "critical",
+			BlastRadius: &config.BlastRadiusConfig{
+				MaxDeletions: &maxDel,
+				ExcludeDrift: &excludeTrue,
+			},
+		},
+	})
+
+	// 3 deletions, but 2 are drift → only 1 non-drift deletion → should NOT trigger (1 is not > 1)
+	a.SetDriftAddresses(map[string]struct{}{
+		"rg.drift1": {},
+		"rg.drift2": {},
+	})
+
+	changes := []plan.ResourceChange{
+		{Address: "rg.drift1", Type: "azurerm_resource_group", Actions: []string{"delete"}},
+		{Address: "rg.drift2", Type: "azurerm_resource_group", Actions: []string{"delete"}},
+		{Address: "rg.intentional", Type: "azurerm_resource_group", Actions: []string{"delete"}},
+	}
+
+	decisions := a.Analyze(changes)
+	if len(decisions) != 0 {
+		t.Errorf("expected no decisions when drift excluded brings count below threshold, got %d", len(decisions))
+	}
+}
+
+func TestBlastRadius_ExcludeDrift_StillTriggered(t *testing.T) {
+	maxDel := 1
+	excludeTrue := true
+	a := NewBlastRadiusAnalyzer([]config.ClassificationConfig{
+		{
+			Name: "critical",
+			BlastRadius: &config.BlastRadiusConfig{
+				MaxDeletions: &maxDel,
+				ExcludeDrift: &excludeTrue,
+			},
+		},
+	})
+
+	// 3 deletions, 1 is drift → 2 non-drift deletions → should trigger (2 > 1)
+	a.SetDriftAddresses(map[string]struct{}{
+		"rg.drift1": {},
+	})
+
+	changes := []plan.ResourceChange{
+		{Address: "rg.drift1", Type: "azurerm_resource_group", Actions: []string{"delete"}},
+		{Address: "rg.intentional1", Type: "azurerm_resource_group", Actions: []string{"delete"}},
+		{Address: "rg.intentional2", Type: "azurerm_resource_group", Actions: []string{"delete"}},
+	}
+
+	decisions := a.Analyze(changes)
+	if len(decisions) == 0 {
+		t.Error("expected decisions when non-drift count exceeds threshold")
+	}
+}
+
+func TestBlastRadius_ExcludeDriftFalse(t *testing.T) {
+	maxDel := 1
+	excludeFalse := false
+	a := NewBlastRadiusAnalyzer([]config.ClassificationConfig{
+		{
+			Name: "critical",
+			BlastRadius: &config.BlastRadiusConfig{
+				MaxDeletions: &maxDel,
+				ExcludeDrift: &excludeFalse,
+			},
+		},
+	})
+
+	a.SetDriftAddresses(map[string]struct{}{
+		"rg.drift1": {},
+		"rg.drift2": {},
+	})
+
+	changes := []plan.ResourceChange{
+		{Address: "rg.drift1", Type: "azurerm_resource_group", Actions: []string{"delete"}},
+		{Address: "rg.drift2", Type: "azurerm_resource_group", Actions: []string{"delete"}},
+	}
+
+	// exclude_drift = false, so drift resources ARE counted → 2 > 1 → trigger
+	decisions := a.Analyze(changes)
+	if len(decisions) == 0 {
+		t.Error("expected decisions when exclude_drift is false")
+	}
+}
+
+func TestRunBuiltinAnalyzers_WithDriftAnalyzer(t *testing.T) {
+	cfg := &config.Config{
+		Classifications: []config.ClassificationConfig{
+			{Name: "critical", Description: "Critical", Rules: []config.RuleConfig{{Resource: []string{"never_*"}}}},
+			{Name: "standard", Description: "Standard", Rules: []config.RuleConfig{{Resource: []string{"*"}}}},
+		},
+		Precedence: []string{"critical", "standard"},
+		Defaults:   &config.DefaultsConfig{Unclassified: "standard", NoChanges: "standard"},
+	}
+
+	classifier, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+
+	planResult := &plan.ParseResult{
+		Changes: []plan.ResourceChange{
+			{Address: "azurerm_resource_group.main", Type: "azurerm_resource_group", Actions: []string{"update"}},
+		},
+		DriftChanges: []plan.ResourceChange{
+			{Address: "azurerm_resource_group.main", Type: "azurerm_resource_group", Actions: []string{"update"}},
+		},
+	}
+
+	result := classifier.Classify(planResult.Changes)
+
+	driftAnalyzer := &DriftAnalyzer{DriftClassification: "critical"}
+	classifier.RunBuiltinAnalyzers(result, planResult, nil, []PlanAwareAnalyzer{driftAnalyzer})
+
+	if result.ResourceDecisions[0].Classification != "critical" {
+		t.Errorf("expected drift to upgrade to 'critical', got %q", result.ResourceDecisions[0].Classification)
+	}
+}

--- a/internal/classify/matcher.go
+++ b/internal/classify/matcher.go
@@ -14,6 +14,8 @@ type compiledRule struct {
 	classificationDescription string
 	resourceGlobs             []glob.Glob
 	notResourceGlobs          []glob.Glob
+	moduleGlobs               []glob.Glob
+	notModuleGlobs            []glob.Glob
 	actions                   map[string]struct{} // pre-computed set for O(1) lookup
 	notActions                map[string]struct{} // pre-computed exclusion set for O(1) lookup
 	ruleDescription           string
@@ -77,6 +79,24 @@ func compileRules(cfg *config.Config) (map[string][]compiledRule, error) {
 				compiled.notResourceGlobs = append(compiled.notResourceGlobs, g)
 			}
 
+			// Compile module globs (dot separator: * matches one level, ** matches any depth)
+			for _, pattern := range rule.Module {
+				g, err := glob.Compile(pattern, '.')
+				if err != nil {
+					return nil, err
+				}
+				compiled.moduleGlobs = append(compiled.moduleGlobs, g)
+			}
+
+			// Compile not_module globs
+			for _, pattern := range rule.NotModule {
+				g, err := glob.Compile(pattern, '.')
+				if err != nil {
+					return nil, err
+				}
+				compiled.notModuleGlobs = append(compiled.notModuleGlobs, g)
+			}
+
 			rules = append(rules, compiled)
 		}
 
@@ -109,6 +129,33 @@ func (r *compiledRule) matchesResource(resourceType string) bool {
 	}
 
 	return false
+}
+
+// matchesModule returns true if the module address matches this rule's module patterns.
+// If neither module nor not_module is specified, matches everything (backward compatible).
+func (r *compiledRule) matchesModule(moduleAddress string) bool {
+	// If module globs are specified, check if address matches any of them
+	if len(r.moduleGlobs) > 0 {
+		for _, g := range r.moduleGlobs {
+			if g.Match(moduleAddress) {
+				return true
+			}
+		}
+		return false
+	}
+
+	// If not_module globs are specified, check if address does NOT match any of them
+	if len(r.notModuleGlobs) > 0 {
+		for _, g := range r.notModuleGlobs {
+			if g.Match(moduleAddress) {
+				return false
+			}
+		}
+		return true
+	}
+
+	// Neither specified: match everything
+	return true
 }
 
 // matchesActions returns true if the change actions match this rule's action constraints.
@@ -152,6 +199,20 @@ func formatRuleDescription(classification string, ruleIndex int, rule config.Rul
 	} else if len(rule.NotResource) > 0 {
 		part := "not_resource: " + rule.NotResource[0]
 		if len(rule.NotResource) > 1 {
+			part += ", ..."
+		}
+		parts = append(parts, part)
+	}
+
+	if len(rule.Module) > 0 {
+		part := "module: " + rule.Module[0]
+		if len(rule.Module) > 1 {
+			part += ", ..."
+		}
+		parts = append(parts, part)
+	} else if len(rule.NotModule) > 0 {
+		part := "not_module: " + rule.NotModule[0]
+		if len(rule.NotModule) > 1 {
 			part += ", ..."
 		}
 		parts = append(parts, part)

--- a/internal/classify/matcher_test.go
+++ b/internal/classify/matcher_test.go
@@ -197,6 +197,164 @@ func TestMatchesActions_NeitherActionsNorNotActions(t *testing.T) {
 	}
 }
 
+func TestMatchesModule_NoModuleSpecified(t *testing.T) {
+	// Rule with no module/not_module should match everything
+	rule := compiledRule{}
+	if !rule.matchesModule("") {
+		t.Error("expected empty module address to match rule with no module constraint")
+	}
+	if !rule.matchesModule("module.production") {
+		t.Error("expected module.production to match rule with no module constraint")
+	}
+}
+
+func TestMatchesModule_MatchExact(t *testing.T) {
+	cfg := &config.Config{
+		Classifications: []config.ClassificationConfig{
+			{
+				Name: "critical",
+				Rules: []config.RuleConfig{
+					{Resource: []string{"*"}, Module: []string{"module.production"}},
+				},
+			},
+		},
+	}
+
+	matchers, err := compileRules(cfg)
+	if err != nil {
+		t.Fatalf("failed to compile rules: %v", err)
+	}
+
+	rules := matchers["critical"]
+	if !rules[0].matchesModule("module.production") {
+		t.Error("expected module.production to match exact module pattern")
+	}
+	if rules[0].matchesModule("module.staging") {
+		t.Error("expected module.staging NOT to match module.production pattern")
+	}
+	if rules[0].matchesModule("") {
+		t.Error("expected root module NOT to match module.production pattern")
+	}
+}
+
+func TestMatchesModule_WildcardSingleLevel(t *testing.T) {
+	cfg := &config.Config{
+		Classifications: []config.ClassificationConfig{
+			{
+				Name: "critical",
+				Rules: []config.RuleConfig{
+					{Resource: []string{"*"}, Module: []string{"module.*"}},
+				},
+			},
+		},
+	}
+
+	matchers, err := compileRules(cfg)
+	if err != nil {
+		t.Fatalf("failed to compile rules: %v", err)
+	}
+
+	rules := matchers["critical"]
+	if !rules[0].matchesModule("module.production") {
+		t.Error("expected module.production to match module.* pattern")
+	}
+	if !rules[0].matchesModule("module.staging") {
+		t.Error("expected module.staging to match module.* pattern")
+	}
+	// With dot separator, * should NOT match nested modules
+	if rules[0].matchesModule("module.production.module.network") {
+		t.Error("expected module.production.module.network NOT to match module.* (single level)")
+	}
+}
+
+func TestMatchesModule_WildcardMultiLevel(t *testing.T) {
+	cfg := &config.Config{
+		Classifications: []config.ClassificationConfig{
+			{
+				Name: "critical",
+				Rules: []config.RuleConfig{
+					{Resource: []string{"*"}, Module: []string{"module.production.**"}},
+				},
+			},
+		},
+	}
+
+	matchers, err := compileRules(cfg)
+	if err != nil {
+		t.Fatalf("failed to compile rules: %v", err)
+	}
+
+	rules := matchers["critical"]
+	if !rules[0].matchesModule("module.production.module.network") {
+		t.Error("expected module.production.module.network to match module.production.** pattern")
+	}
+	if !rules[0].matchesModule("module.production.module.network.module.subnet") {
+		t.Error("expected deeply nested module to match module.production.** pattern")
+	}
+	if rules[0].matchesModule("module.staging.module.network") {
+		t.Error("expected module.staging.module.network NOT to match module.production.** pattern")
+	}
+}
+
+func TestMatchesModule_NotModule(t *testing.T) {
+	cfg := &config.Config{
+		Classifications: []config.ClassificationConfig{
+			{
+				Name: "standard",
+				Rules: []config.RuleConfig{
+					{Resource: []string{"*"}, NotModule: []string{"module.production", "module.production.**"}},
+				},
+			},
+		},
+	}
+
+	matchers, err := compileRules(cfg)
+	if err != nil {
+		t.Fatalf("failed to compile rules: %v", err)
+	}
+
+	rules := matchers["standard"]
+	if rules[0].matchesModule("module.production") {
+		t.Error("expected module.production NOT to match not_module pattern")
+	}
+	if rules[0].matchesModule("module.production.module.network") {
+		t.Error("expected module.production.module.network NOT to match not_module pattern")
+	}
+	if !rules[0].matchesModule("module.staging") {
+		t.Error("expected module.staging to match not_module (excluded production)")
+	}
+	if !rules[0].matchesModule("") {
+		t.Error("expected root module to match not_module (excluded production)")
+	}
+}
+
+func TestMatchesModule_RootModuleEmptyString(t *testing.T) {
+	cfg := &config.Config{
+		Classifications: []config.ClassificationConfig{
+			{
+				Name: "critical",
+				Rules: []config.RuleConfig{
+					// Empty string matches root module resources
+					{Resource: []string{"*"}, Module: []string{""}},
+				},
+			},
+		},
+	}
+
+	matchers, err := compileRules(cfg)
+	if err != nil {
+		t.Fatalf("failed to compile rules: %v", err)
+	}
+
+	rules := matchers["critical"]
+	if !rules[0].matchesModule("") {
+		t.Error("expected root module (empty string) to match empty module pattern")
+	}
+	if rules[0].matchesModule("module.production") {
+		t.Error("expected module.production NOT to match empty module pattern")
+	}
+}
+
 func TestMatchesResource_NoGlobsSpecified(t *testing.T) {
 	// A rule with neither resource nor not_resource globs should not match anything.
 	// This is an edge case that shouldn't occur in valid configs (validation should catch it),

--- a/internal/classify/topology.go
+++ b/internal/classify/topology.go
@@ -1,0 +1,266 @@
+package classify
+
+import (
+	"fmt"
+	"strings"
+
+	tfjson "github.com/hashicorp/terraform-json"
+	"github.com/jokarl/tfclassify/internal/config"
+	"github.com/jokarl/tfclassify/internal/plan"
+)
+
+// DependencyGraph represents the directed dependency graph between resources.
+// An edge from A to B means "B depends on A" (a change to A propagates to B).
+type DependencyGraph struct {
+	// downstream maps resource address → list of downstream dependents
+	downstream map[string][]string
+}
+
+// BuildDependencyGraph walks the Terraform config to build a resource dependency graph.
+// References like "azurerm_network_security_group.main.id" are parsed to extract the
+// source resource address, and an edge A → B is created (A's change propagates to B).
+func BuildDependencyGraph(cfg *tfjson.Config) *DependencyGraph {
+	g := &DependencyGraph{downstream: make(map[string][]string)}
+	if cfg == nil || cfg.RootModule == nil {
+		return g
+	}
+	g.walkModule(cfg.RootModule, "")
+	return g
+}
+
+// walkModule recursively walks a module config and its child module calls.
+func (g *DependencyGraph) walkModule(mod *tfjson.ConfigModule, modulePrefix string) {
+	if mod == nil {
+		return
+	}
+
+	for _, res := range mod.Resources {
+		targetAddr := qualifyAddress(modulePrefix, res.Address)
+
+		// Ensure the node exists in the graph
+		if _, ok := g.downstream[targetAddr]; !ok {
+			g.downstream[targetAddr] = nil
+		}
+
+		// Extract references from expressions
+		refs := extractReferences(res.Expressions)
+		for _, ref := range refs {
+			sourceAddr := resolveReference(modulePrefix, ref)
+			if sourceAddr == "" || sourceAddr == targetAddr {
+				continue
+			}
+			g.downstream[sourceAddr] = append(g.downstream[sourceAddr], targetAddr)
+		}
+	}
+
+	// Recurse into child module calls
+	for callName, call := range mod.ModuleCalls {
+		childPrefix := qualifyModulePrefix(modulePrefix, callName)
+		if call.Module != nil {
+			g.walkModule(call.Module, childPrefix)
+		}
+	}
+}
+
+// qualifyAddress prepends the module prefix to a resource address.
+func qualifyAddress(modulePrefix, address string) string {
+	if modulePrefix == "" {
+		return address
+	}
+	return modulePrefix + "." + address
+}
+
+// qualifyModulePrefix builds a nested module prefix.
+func qualifyModulePrefix(parent, childName string) string {
+	child := "module." + childName
+	if parent == "" {
+		return child
+	}
+	return parent + "." + child
+}
+
+// resolveReference parses a Terraform reference string and resolves it to a resource address.
+// References like "azurerm_network_security_group.main.id" resolve to
+// "azurerm_network_security_group.main". Module references like
+// "module.network.azurerm_vnet.main" are handled by qualifying with the module prefix.
+func resolveReference(modulePrefix, ref string) string {
+	// Skip non-resource references
+	if strings.HasPrefix(ref, "var.") ||
+		strings.HasPrefix(ref, "local.") ||
+		strings.HasPrefix(ref, "data.") ||
+		strings.HasPrefix(ref, "each.") ||
+		strings.HasPrefix(ref, "count.") ||
+		strings.HasPrefix(ref, "terraform.") ||
+		strings.HasPrefix(ref, "path.") ||
+		strings.HasPrefix(ref, "null_resource.") {
+		return ""
+	}
+
+	// Handle module references: "module.name.output"
+	if strings.HasPrefix(ref, "module.") {
+		// Module output references don't map to a single resource
+		return ""
+	}
+
+	// Standard resource reference: "resource_type.name" or "resource_type.name.attribute"
+	parts := strings.Split(ref, ".")
+	if len(parts) < 2 {
+		return ""
+	}
+
+	// The resource address is the first two parts: type.name
+	resourceAddr := parts[0] + "." + parts[1]
+	return qualifyAddress(modulePrefix, resourceAddr)
+}
+
+// extractReferences collects all reference strings from a resource's expressions.
+func extractReferences(expressions map[string]*tfjson.Expression) []string {
+	if expressions == nil {
+		return nil
+	}
+
+	var refs []string
+	for _, expr := range expressions {
+		refs = append(refs, collectExprRefs(expr)...)
+	}
+	return refs
+}
+
+// collectExprRefs recursively collects references from an expression and its nested expressions.
+func collectExprRefs(expr *tfjson.Expression) []string {
+	if expr == nil {
+		return nil
+	}
+	var refs []string
+	if expr.ExpressionData == nil {
+		return nil
+	}
+	refs = append(refs, expr.References...)
+	for _, nested := range expr.NestedBlocks {
+		for _, nestedExpr := range nested {
+			refs = append(refs, collectExprRefs(nestedExpr)...)
+		}
+	}
+	return refs
+}
+
+// Downstream returns the list of downstream dependents for a resource.
+func (g *DependencyGraph) Downstream(address string) []string {
+	return g.downstream[address]
+}
+
+// computeDownstreamFanOut computes the total number of downstream resources and max depth
+// reachable from a starting resource via BFS.
+func (g *DependencyGraph) computeDownstreamFanOut(address string) (count int, maxDepth int) {
+	visited := make(map[string]bool)
+	visited[address] = true
+
+	type queueItem struct {
+		addr  string
+		depth int
+	}
+
+	queue := []queueItem{{addr: address, depth: 0}}
+	for len(queue) > 0 {
+		item := queue[0]
+		queue = queue[1:]
+
+		for _, dep := range g.downstream[item.addr] {
+			if visited[dep] {
+				continue
+			}
+			visited[dep] = true
+			count++
+			depth := item.depth + 1
+			if depth > maxDepth {
+				maxDepth = depth
+			}
+			queue = append(queue, queueItem{addr: dep, depth: depth})
+		}
+	}
+
+	return count, maxDepth
+}
+
+// TopologyAnalyzer inspects the Terraform dependency graph and flags resources
+// whose change propagation exceeds configured thresholds.
+type TopologyAnalyzer struct {
+	thresholds map[string]*config.TopologyConfig
+}
+
+// NewTopologyAnalyzer creates a TopologyAnalyzer from the classification configs.
+func NewTopologyAnalyzer(classifications []config.ClassificationConfig) *TopologyAnalyzer {
+	thresholds := make(map[string]*config.TopologyConfig)
+	for _, c := range classifications {
+		if c.Topology != nil {
+			thresholds[c.Name] = c.Topology
+		}
+	}
+	return &TopologyAnalyzer{thresholds: thresholds}
+}
+
+// Thresholds returns the thresholds map for checking if the analyzer has any config.
+func (a *TopologyAnalyzer) Thresholds() map[string]*config.TopologyConfig {
+	return a.thresholds
+}
+
+// Name returns the analyzer name.
+func (a *TopologyAnalyzer) Name() string {
+	return "topology"
+}
+
+// AnalyzePlan builds the dependency graph from the plan config and checks
+// each changed resource's downstream fan-out against configured thresholds.
+func (a *TopologyAnalyzer) AnalyzePlan(result *plan.ParseResult) []ResourceDecision {
+	if len(a.thresholds) == 0 {
+		return nil
+	}
+	if result.Config == nil {
+		return nil
+	}
+
+	graph := BuildDependencyGraph(result.Config)
+
+	// Build set of changed resource addresses
+	changedAddrs := make(map[string]bool, len(result.Changes))
+	for _, change := range result.Changes {
+		if !isNoOp(change.Actions) {
+			changedAddrs[change.Address] = true
+		}
+	}
+
+	var decisions []ResourceDecision
+	for classificationName, topo := range a.thresholds {
+		for _, change := range result.Changes {
+			if isNoOp(change.Actions) {
+				continue
+			}
+
+			count, depth := graph.computeDownstreamFanOut(change.Address)
+
+			var reasons []string
+			if topo.MaxDownstream != nil && count > *topo.MaxDownstream {
+				reasons = append(reasons, fmt.Sprintf(
+					"builtin: topology - Resource %s change propagates to %d downstream resources (threshold: %d)",
+					change.Address, count, *topo.MaxDownstream))
+			}
+			if topo.MaxPropagationDepth != nil && depth > *topo.MaxPropagationDepth {
+				reasons = append(reasons, fmt.Sprintf(
+					"builtin: topology - Resource %s change cascades %d levels deep (threshold: %d)",
+					change.Address, depth, *topo.MaxPropagationDepth))
+			}
+
+			if len(reasons) > 0 {
+				decisions = append(decisions, ResourceDecision{
+					Address:        change.Address,
+					ResourceType:   change.Type,
+					Actions:        change.Actions,
+					Classification: classificationName,
+					MatchedRules:   reasons,
+				})
+			}
+		}
+	}
+
+	return decisions
+}

--- a/internal/classify/topology_test.go
+++ b/internal/classify/topology_test.go
@@ -1,0 +1,448 @@
+package classify
+
+import (
+	"testing"
+
+	tfjson "github.com/hashicorp/terraform-json"
+	"github.com/jokarl/tfclassify/internal/config"
+	"github.com/jokarl/tfclassify/internal/plan"
+)
+
+// exprWithRefs creates a tfjson.Expression with the given references.
+func exprWithRefs(refs ...string) *tfjson.Expression {
+	return &tfjson.Expression{
+		ExpressionData: &tfjson.ExpressionData{
+			References: refs,
+		},
+	}
+}
+
+func TestBuildDependencyGraph_NilConfig(t *testing.T) {
+	g := BuildDependencyGraph(nil)
+	if len(g.downstream) != 0 {
+		t.Errorf("expected empty graph for nil config, got %d entries", len(g.downstream))
+	}
+}
+
+func TestBuildDependencyGraph_EmptyModule(t *testing.T) {
+	cfg := &tfjson.Config{
+		RootModule: &tfjson.ConfigModule{},
+	}
+	g := BuildDependencyGraph(cfg)
+	if len(g.downstream) != 0 {
+		t.Errorf("expected empty graph for empty module, got %d entries", len(g.downstream))
+	}
+}
+
+func TestBuildDependencyGraph_SimpleReference(t *testing.T) {
+	cfg := &tfjson.Config{
+		RootModule: &tfjson.ConfigModule{
+			Resources: []*tfjson.ConfigResource{
+				{
+					Address: "azurerm_resource_group.main",
+					Type:    "azurerm_resource_group",
+				},
+				{
+					Address: "azurerm_virtual_network.main",
+					Type:    "azurerm_virtual_network",
+					Expressions: map[string]*tfjson.Expression{
+						"resource_group_name": exprWithRefs("azurerm_resource_group.main.name"),
+					},
+				},
+			},
+		},
+	}
+
+	g := BuildDependencyGraph(cfg)
+
+	// azurerm_resource_group.main → azurerm_virtual_network.main
+	downstream := g.Downstream("azurerm_resource_group.main")
+	if len(downstream) != 1 {
+		t.Fatalf("expected 1 downstream for resource_group, got %d", len(downstream))
+	}
+	if downstream[0] != "azurerm_virtual_network.main" {
+		t.Errorf("expected downstream azurerm_virtual_network.main, got %s", downstream[0])
+	}
+}
+
+func TestBuildDependencyGraph_ChainedDependencies(t *testing.T) {
+	// A → B → C
+	cfg := &tfjson.Config{
+		RootModule: &tfjson.ConfigModule{
+			Resources: []*tfjson.ConfigResource{
+				{Address: "a.one", Type: "a"},
+				{
+					Address: "b.one",
+					Type:    "b",
+					Expressions: map[string]*tfjson.Expression{
+						"ref": exprWithRefs("a.one.id"),
+					},
+				},
+				{
+					Address: "c.one",
+					Type:    "c",
+					Expressions: map[string]*tfjson.Expression{
+						"ref": exprWithRefs("b.one.id"),
+					},
+				},
+			},
+		},
+	}
+
+	g := BuildDependencyGraph(cfg)
+
+	count, depth := g.computeDownstreamFanOut("a.one")
+	if count != 2 {
+		t.Errorf("expected 2 downstream from a.one, got %d", count)
+	}
+	if depth != 2 {
+		t.Errorf("expected depth 2 from a.one, got %d", depth)
+	}
+}
+
+func TestBuildDependencyGraph_FanOut(t *testing.T) {
+	// A → B, A → C, A → D
+	cfg := &tfjson.Config{
+		RootModule: &tfjson.ConfigModule{
+			Resources: []*tfjson.ConfigResource{
+				{Address: "a.one", Type: "a"},
+				{
+					Address:     "b.one",
+					Type:        "b",
+					Expressions: map[string]*tfjson.Expression{"ref": exprWithRefs("a.one.id")},
+				},
+				{
+					Address:     "c.one",
+					Type:        "c",
+					Expressions: map[string]*tfjson.Expression{"ref": exprWithRefs("a.one.id")},
+				},
+				{
+					Address:     "d.one",
+					Type:        "d",
+					Expressions: map[string]*tfjson.Expression{"ref": exprWithRefs("a.one.id")},
+				},
+			},
+		},
+	}
+
+	g := BuildDependencyGraph(cfg)
+
+	count, depth := g.computeDownstreamFanOut("a.one")
+	if count != 3 {
+		t.Errorf("expected 3 downstream from a.one, got %d", count)
+	}
+	if depth != 1 {
+		t.Errorf("expected depth 1 from a.one, got %d", depth)
+	}
+}
+
+func TestBuildDependencyGraph_CircularGuard(t *testing.T) {
+	// A → B → A (shouldn't happen in valid TF, but guard against infinite loop)
+	cfg := &tfjson.Config{
+		RootModule: &tfjson.ConfigModule{
+			Resources: []*tfjson.ConfigResource{
+				{
+					Address:     "a.one",
+					Type:        "a",
+					Expressions: map[string]*tfjson.Expression{"ref": exprWithRefs("b.one.id")},
+				},
+				{
+					Address:     "b.one",
+					Type:        "b",
+					Expressions: map[string]*tfjson.Expression{"ref": exprWithRefs("a.one.id")},
+				},
+			},
+		},
+	}
+
+	g := BuildDependencyGraph(cfg)
+
+	// Should not hang; visited set prevents infinite loop
+	count, depth := g.computeDownstreamFanOut("a.one")
+	if count != 1 {
+		t.Errorf("expected 1 downstream (b.one) from a.one in circular, got %d", count)
+	}
+	if depth != 1 {
+		t.Errorf("expected depth 1 from a.one in circular, got %d", depth)
+	}
+}
+
+func TestBuildDependencyGraph_SkipsNonResourceRefs(t *testing.T) {
+	cfg := &tfjson.Config{
+		RootModule: &tfjson.ConfigModule{
+			Resources: []*tfjson.ConfigResource{
+				{
+					Address: "a.one",
+					Type:    "a",
+					Expressions: map[string]*tfjson.Expression{
+						"ref": exprWithRefs(
+							"var.name",
+							"local.value",
+							"data.something.id",
+							"each.key",
+							"count.index",
+						),
+					},
+				},
+			},
+		},
+	}
+
+	g := BuildDependencyGraph(cfg)
+
+	downstream := g.Downstream("a.one")
+	if len(downstream) != 0 {
+		t.Errorf("expected 0 downstream (non-resource refs filtered), got %d: %v", len(downstream), downstream)
+	}
+}
+
+func TestBuildDependencyGraph_ModuleCalls(t *testing.T) {
+	cfg := &tfjson.Config{
+		RootModule: &tfjson.ConfigModule{
+			Resources: []*tfjson.ConfigResource{
+				{Address: "a.root", Type: "a"},
+			},
+			ModuleCalls: map[string]*tfjson.ModuleCall{
+				"network": {
+					Module: &tfjson.ConfigModule{
+						Resources: []*tfjson.ConfigResource{
+							{Address: "b.child", Type: "b"},
+							{
+								Address: "c.child",
+								Type:    "c",
+								Expressions: map[string]*tfjson.Expression{
+									"ref": exprWithRefs("b.child.id"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	g := BuildDependencyGraph(cfg)
+
+	// b.child within module.network should have qualified address
+	downstream := g.Downstream("module.network.b.child")
+	if len(downstream) != 1 {
+		t.Fatalf("expected 1 downstream for module.network.b.child, got %d", len(downstream))
+	}
+	if downstream[0] != "module.network.c.child" {
+		t.Errorf("expected downstream module.network.c.child, got %s", downstream[0])
+	}
+}
+
+func TestTopologyAnalyzer_NilConfig(t *testing.T) {
+	maxDown := 5
+	a := NewTopologyAnalyzer([]config.ClassificationConfig{
+		{Name: "critical", Topology: &config.TopologyConfig{MaxDownstream: &maxDown}},
+	})
+
+	result := &plan.ParseResult{
+		Changes: []plan.ResourceChange{
+			{Address: "a.one", Type: "a", Actions: []string{"update"}},
+		},
+		Config: nil,
+	}
+
+	decisions := a.AnalyzePlan(result)
+	if len(decisions) != 0 {
+		t.Errorf("expected no decisions when Config is nil, got %d", len(decisions))
+	}
+}
+
+func TestTopologyAnalyzer_NoThresholds(t *testing.T) {
+	a := NewTopologyAnalyzer(nil)
+	result := &plan.ParseResult{
+		Changes: []plan.ResourceChange{
+			{Address: "a.one", Type: "a", Actions: []string{"update"}},
+		},
+	}
+	decisions := a.AnalyzePlan(result)
+	if len(decisions) != 0 {
+		t.Errorf("expected no decisions with no thresholds, got %d", len(decisions))
+	}
+}
+
+func TestTopologyAnalyzer_MaxDownstreamExceeded(t *testing.T) {
+	maxDown := 2
+	a := NewTopologyAnalyzer([]config.ClassificationConfig{
+		{Name: "critical", Topology: &config.TopologyConfig{MaxDownstream: &maxDown}},
+	})
+
+	// a.one → b.one, c.one, d.one (fan-out of 3 > threshold of 2)
+	result := &plan.ParseResult{
+		Changes: []plan.ResourceChange{
+			{Address: "a.one", Type: "a", Actions: []string{"update"}},
+			{Address: "b.one", Type: "b", Actions: []string{"no-op"}},
+		},
+		Config: &tfjson.Config{
+			RootModule: &tfjson.ConfigModule{
+				Resources: []*tfjson.ConfigResource{
+					{Address: "a.one", Type: "a"},
+					{Address: "b.one", Type: "b", Expressions: map[string]*tfjson.Expression{"ref": exprWithRefs("a.one.id")}},
+					{Address: "c.one", Type: "c", Expressions: map[string]*tfjson.Expression{"ref": exprWithRefs("a.one.id")}},
+					{Address: "d.one", Type: "d", Expressions: map[string]*tfjson.Expression{"ref": exprWithRefs("a.one.id")}},
+				},
+			},
+		},
+	}
+
+	decisions := a.AnalyzePlan(result)
+	if len(decisions) != 1 {
+		t.Fatalf("expected 1 decision for a.one exceeding threshold, got %d", len(decisions))
+	}
+	if decisions[0].Address != "a.one" {
+		t.Errorf("expected decision for a.one, got %s", decisions[0].Address)
+	}
+	if decisions[0].Classification != "critical" {
+		t.Errorf("expected classification 'critical', got %q", decisions[0].Classification)
+	}
+}
+
+func TestTopologyAnalyzer_MaxDepthExceeded(t *testing.T) {
+	maxDepth := 1
+	a := NewTopologyAnalyzer([]config.ClassificationConfig{
+		{Name: "critical", Topology: &config.TopologyConfig{MaxPropagationDepth: &maxDepth}},
+	})
+
+	// a.one → b.one → c.one (depth 2 > threshold of 1)
+	result := &plan.ParseResult{
+		Changes: []plan.ResourceChange{
+			{Address: "a.one", Type: "a", Actions: []string{"update"}},
+		},
+		Config: &tfjson.Config{
+			RootModule: &tfjson.ConfigModule{
+				Resources: []*tfjson.ConfigResource{
+					{Address: "a.one", Type: "a"},
+					{Address: "b.one", Type: "b", Expressions: map[string]*tfjson.Expression{"ref": exprWithRefs("a.one.id")}},
+					{Address: "c.one", Type: "c", Expressions: map[string]*tfjson.Expression{"ref": exprWithRefs("b.one.id")}},
+				},
+			},
+		},
+	}
+
+	decisions := a.AnalyzePlan(result)
+	if len(decisions) != 1 {
+		t.Fatalf("expected 1 decision for a.one exceeding depth, got %d", len(decisions))
+	}
+}
+
+func TestTopologyAnalyzer_BelowThreshold(t *testing.T) {
+	maxDown := 10
+	a := NewTopologyAnalyzer([]config.ClassificationConfig{
+		{Name: "critical", Topology: &config.TopologyConfig{MaxDownstream: &maxDown}},
+	})
+
+	// a.one → b.one (fan-out of 1, well below 10)
+	result := &plan.ParseResult{
+		Changes: []plan.ResourceChange{
+			{Address: "a.one", Type: "a", Actions: []string{"update"}},
+		},
+		Config: &tfjson.Config{
+			RootModule: &tfjson.ConfigModule{
+				Resources: []*tfjson.ConfigResource{
+					{Address: "a.one", Type: "a"},
+					{Address: "b.one", Type: "b", Expressions: map[string]*tfjson.Expression{"ref": exprWithRefs("a.one.id")}},
+				},
+			},
+		},
+	}
+
+	decisions := a.AnalyzePlan(result)
+	if len(decisions) != 0 {
+		t.Errorf("expected no decisions when below threshold, got %d", len(decisions))
+	}
+}
+
+func TestTopologyAnalyzer_SkipsNoOp(t *testing.T) {
+	maxDown := 0
+	a := NewTopologyAnalyzer([]config.ClassificationConfig{
+		{Name: "critical", Topology: &config.TopologyConfig{MaxDownstream: &maxDown}},
+	})
+
+	result := &plan.ParseResult{
+		Changes: []plan.ResourceChange{
+			{Address: "a.one", Type: "a", Actions: []string{"no-op"}},
+		},
+		Config: &tfjson.Config{
+			RootModule: &tfjson.ConfigModule{
+				Resources: []*tfjson.ConfigResource{
+					{Address: "a.one", Type: "a"},
+					{Address: "b.one", Type: "b", Expressions: map[string]*tfjson.Expression{"ref": exprWithRefs("a.one.id")}},
+				},
+			},
+		},
+	}
+
+	decisions := a.AnalyzePlan(result)
+	if len(decisions) != 0 {
+		t.Errorf("expected no decisions for no-op resources, got %d", len(decisions))
+	}
+}
+
+func TestTopologyAnalyzer_Name(t *testing.T) {
+	a := &TopologyAnalyzer{}
+	if a.Name() != "topology" {
+		t.Errorf("expected name 'topology', got %q", a.Name())
+	}
+}
+
+func TestResolveReference(t *testing.T) {
+	tests := []struct {
+		prefix string
+		ref    string
+		want   string
+	}{
+		{"", "azurerm_resource_group.main.name", "azurerm_resource_group.main"},
+		{"", "azurerm_resource_group.main", "azurerm_resource_group.main"},
+		{"module.net", "azurerm_vnet.main.id", "module.net.azurerm_vnet.main"},
+		{"", "var.name", ""},
+		{"", "local.value", ""},
+		{"", "data.something.id", ""},
+		{"", "module.net.output", ""},
+		{"", "each.key", ""},
+		{"", "count.index", ""},
+		{"", "x", ""},
+	}
+
+	for _, tt := range tests {
+		got := resolveReference(tt.prefix, tt.ref)
+		if got != tt.want {
+			t.Errorf("resolveReference(%q, %q) = %q, want %q", tt.prefix, tt.ref, got, tt.want)
+		}
+	}
+}
+
+func TestBuildDependencyGraph_NestedExpressions(t *testing.T) {
+	cfg := &tfjson.Config{
+		RootModule: &tfjson.ConfigModule{
+			Resources: []*tfjson.ConfigResource{
+				{Address: "a.one", Type: "a"},
+				{
+					Address: "b.one",
+					Type:    "b",
+					Expressions: map[string]*tfjson.Expression{
+						"block": {
+							ExpressionData: &tfjson.ExpressionData{
+								NestedBlocks: []map[string]*tfjson.Expression{
+									{
+										"inner": exprWithRefs("a.one.id"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	g := BuildDependencyGraph(cfg)
+
+	downstream := g.Downstream("a.one")
+	if len(downstream) != 1 || downstream[0] != "b.one" {
+		t.Errorf("expected a.one → b.one from nested expression, got %v", downstream)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,6 +63,10 @@ type ClassificationConfig struct {
 	// Populated during parsing from blast_radius {} blocks.
 	BlastRadius *BlastRadiusConfig
 
+	// Topology holds the optional topology thresholds for this classification.
+	// Populated during parsing from topology {} blocks.
+	Topology *TopologyConfig
+
 	// PluginAnalyzerConfigs holds per-analyzer configuration for each plugin.
 	// Key is the plugin name (e.g., "azurerm").
 	// This is populated during parsing when plugin-named blocks are found.
@@ -139,6 +143,17 @@ type BlastRadiusConfig struct {
 	MaxReplacements *int `json:"max_replacements,omitempty"`
 	// MaxChanges triggers when total non-no-op changes exceed this count.
 	MaxChanges *int `json:"max_changes,omitempty"`
+	// ExcludeDrift, when true, excludes drift-corrected resources from blast radius counts.
+	ExcludeDrift *bool `json:"exclude_drift,omitempty"`
+}
+
+// TopologyConfig holds thresholds for the topology analyzer.
+// Each field is a pointer so that omitted fields are distinguishable from zero.
+type TopologyConfig struct {
+	// MaxDownstream triggers when a single resource's change propagates to more than N downstream resources.
+	MaxDownstream *int `json:"max_downstream,omitempty"`
+	// MaxPropagationDepth triggers when a change cascades more than N levels deep.
+	MaxPropagationDepth *int `json:"max_propagation_depth,omitempty"`
 }
 
 // RuleConfig represents a classification rule.
@@ -148,11 +163,14 @@ type RuleConfig struct {
 	NotResource []string `hcl:"not_resource,optional"`
 	Actions     []string `hcl:"actions,optional"`
 	NotActions  []string `hcl:"not_actions,optional"`
+	Module      []string `hcl:"module,optional"`
+	NotModule   []string `hcl:"not_module,optional"`
 }
 
 // DefaultsConfig contains default configuration values.
 type DefaultsConfig struct {
-	Unclassified  string `hcl:"unclassified"`
-	NoChanges     string `hcl:"no_changes"`
-	PluginTimeout string `hcl:"plugin_timeout,optional"`
+	Unclassified        string `hcl:"unclassified"`
+	NoChanges           string `hcl:"no_changes"`
+	PluginTimeout       string `hcl:"plugin_timeout,optional"`
+	DriftClassification string `hcl:"drift_classification,optional"`
 }

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -113,6 +113,16 @@ func parseClassificationPluginBlocks(cfg *Config, body hcl.Body) error {
 				continue
 			}
 
+			// Parse topology blocks
+			if subBlock.Type == "topology" {
+				topoConfig := &TopologyConfig{}
+				if err := parseTopologyConfig(subBlock, topoConfig); err != nil {
+					return fmt.Errorf("classification %q: %w", classification.Name, err)
+				}
+				classification.Topology = topoConfig
+				continue
+			}
+
 			// This is a plugin-named block (e.g., "azurerm")
 			pluginName := subBlock.Type
 
@@ -225,8 +235,35 @@ func parseBlastRadiusConfig(block *hclsyntax.Block, config *BlastRadiusConfig) e
 			n, _ := val.AsBigFloat().Int64()
 			v := int(n)
 			config.MaxChanges = &v
+		case "exclude_drift":
+			b := val.True()
+			config.ExcludeDrift = &b
 		default:
 			return fmt.Errorf("blast_radius: unknown attribute %q", name)
+		}
+	}
+	return nil
+}
+
+// parseTopologyConfig parses attributes from a topology block.
+func parseTopologyConfig(block *hclsyntax.Block, config *TopologyConfig) error {
+	for name, attr := range block.Body.Attributes {
+		val, diags := attr.Expr.Value(nil)
+		if diags.HasErrors() {
+			return fmt.Errorf("topology.%s: %v", name, diags.Error())
+		}
+
+		switch name {
+		case "max_downstream":
+			n, _ := val.AsBigFloat().Int64()
+			v := int(n)
+			config.MaxDownstream = &v
+		case "max_propagation_depth":
+			n, _ := val.AsBigFloat().Int64()
+			v := int(n)
+			config.MaxPropagationDepth = &v
+		default:
+			return fmt.Errorf("topology: unknown attribute %q", name)
 		}
 	}
 	return nil

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -46,6 +46,10 @@ func Validate(cfg *Config) error {
 		return err
 	}
 
+	if err := validateTopology(cfg); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -85,6 +89,10 @@ func validateDefaults(cfg *Config, classificationNames map[string]bool) error {
 		return fmt.Errorf("defaults.no_changes references undefined classification %q", cfg.Defaults.NoChanges)
 	}
 
+	if cfg.Defaults.DriftClassification != "" && !classificationNames[cfg.Defaults.DriftClassification] {
+		return fmt.Errorf("defaults.drift_classification references undefined classification %q", cfg.Defaults.DriftClassification)
+	}
+
 	return nil
 }
 
@@ -121,6 +129,11 @@ func validateRules(cfg *Config) error {
 
 			if len(rule.Actions) > 0 && len(rule.NotActions) > 0 {
 				return fmt.Errorf("classification %q rule %d: cannot combine actions and not_actions in the same rule",
+					classification.Name, i+1)
+			}
+
+			if len(rule.Module) > 0 && len(rule.NotModule) > 0 {
+				return fmt.Errorf("classification %q rule %d: cannot combine module and not_module in the same rule",
 					classification.Name, i+1)
 			}
 
@@ -175,6 +188,25 @@ func validateBlastRadius(cfg *Config) error {
 		if br.MaxChanges != nil && *br.MaxChanges <= 0 {
 			return fmt.Errorf("classification %q: blast_radius.max_changes must be a positive integer, got %d",
 				c.Name, *br.MaxChanges)
+		}
+	}
+	return nil
+}
+
+// validateTopology checks that topology threshold values are positive integers.
+func validateTopology(cfg *Config) error {
+	for _, c := range cfg.Classifications {
+		if c.Topology == nil {
+			continue
+		}
+		topo := c.Topology
+		if topo.MaxDownstream != nil && *topo.MaxDownstream <= 0 {
+			return fmt.Errorf("classification %q: topology.max_downstream must be a positive integer, got %d",
+				c.Name, *topo.MaxDownstream)
+		}
+		if topo.MaxPropagationDepth != nil && *topo.MaxPropagationDepth <= 0 {
+			return fmt.Errorf("classification %q: topology.max_propagation_depth must be a positive integer, got %d",
+				c.Name, *topo.MaxPropagationDepth)
 		}
 	}
 	return nil
@@ -265,6 +297,18 @@ func ValidateGlobPatterns(cfg *Config) error {
 			for _, pattern := range rule.NotResource {
 				if _, err := glob.Compile(pattern); err != nil {
 					return fmt.Errorf("classification %q rule %d: invalid not_resource pattern %q: %w",
+						classification.Name, i+1, pattern, err)
+				}
+			}
+			for _, pattern := range rule.Module {
+				if _, err := glob.Compile(pattern, '.'); err != nil {
+					return fmt.Errorf("classification %q rule %d: invalid module pattern %q: %w",
+						classification.Name, i+1, pattern, err)
+				}
+			}
+			for _, pattern := range rule.NotModule {
+				if _, err := glob.Compile(pattern, '.'); err != nil {
+					return fmt.Errorf("classification %q rule %d: invalid not_module pattern %q: %w",
 						classification.Name, i+1, pattern, err)
 				}
 			}
@@ -361,7 +405,7 @@ func isCatchAllRule(rule RuleConfig) bool {
 func warnEmptyClassifications(cfg *Config) []Warning {
 	var warnings []Warning
 	for _, c := range cfg.Classifications {
-		if len(c.Rules) == 0 && !hasPluginAnalyzers(c) && c.BlastRadius == nil {
+		if len(c.Rules) == 0 && !hasPluginAnalyzers(c) && c.BlastRadius == nil && c.Topology == nil {
 			warnings = append(warnings, Warning{
 				Classification: c.Name,
 				Message:        "has no rules and no plugin analyzer blocks; it will never match any resource",

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -545,6 +545,94 @@ func TestValidate_DuplicatePrecedence_NoDuplicates(t *testing.T) {
 	}
 }
 
+func TestValidateRules_ModuleAndNotModuleMutuallyExclusive(t *testing.T) {
+	cfg := &Config{
+		Classifications: []ClassificationConfig{
+			{
+				Name:        "critical",
+				Description: "Critical",
+				Rules: []RuleConfig{
+					{
+						Resource:  []string{"*"},
+						Module:    []string{"module.production"},
+						NotModule: []string{"module.staging"},
+					},
+				},
+			},
+		},
+		Precedence: []string{"critical"},
+		Defaults:   &DefaultsConfig{Unclassified: "critical", NoChanges: "critical"},
+	}
+
+	err := Validate(cfg)
+	if err == nil {
+		t.Fatal("expected error for rule with both module and not_module, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "cannot combine module and not_module") {
+		t.Errorf("expected mutual exclusivity error, got: %v", err)
+	}
+}
+
+func TestValidateGlobPatterns_ModulePatterns(t *testing.T) {
+	cfg := &Config{
+		Classifications: []ClassificationConfig{
+			{
+				Name: "critical",
+				Rules: []RuleConfig{
+					{Resource: []string{"*"}, Module: []string{"module.production", "module.production.**"}},
+				},
+			},
+		},
+	}
+
+	if err := ValidateGlobPatterns(cfg); err != nil {
+		t.Errorf("expected no error for valid module patterns, got: %v", err)
+	}
+}
+
+func TestValidateGlobPatterns_InvalidModulePattern(t *testing.T) {
+	cfg := &Config{
+		Classifications: []ClassificationConfig{
+			{
+				Name: "critical",
+				Rules: []RuleConfig{
+					{Resource: []string{"*"}, Module: []string{"[bad"}},
+				},
+			},
+		},
+	}
+
+	err := ValidateGlobPatterns(cfg)
+	if err == nil {
+		t.Fatal("expected error for invalid module pattern, got nil")
+	}
+	if !strings.Contains(err.Error(), "module pattern") {
+		t.Errorf("expected error to mention module pattern, got: %v", err)
+	}
+}
+
+func TestValidateGlobPatterns_InvalidNotModulePattern(t *testing.T) {
+	cfg := &Config{
+		Classifications: []ClassificationConfig{
+			{
+				Name: "critical",
+				Rules: []RuleConfig{
+					{Resource: []string{"*"}, NotModule: []string{"[bad"}},
+				},
+			},
+		},
+	}
+
+	err := ValidateGlobPatterns(cfg)
+	if err == nil {
+		t.Fatal("expected error for invalid not_module pattern, got nil")
+	}
+	if !strings.Contains(err.Error(), "not_module pattern") {
+		t.Errorf("expected error to mention not_module pattern, got: %v", err)
+	}
+}
+
 func TestValidateWarnings_EmptyClassification_WithPlugin(t *testing.T) {
 	cfg := &Config{
 		Classifications: []ClassificationConfig{

--- a/internal/plan/parser.go
+++ b/internal/plan/parser.go
@@ -124,11 +124,14 @@ func Parse(r io.Reader) (*ParseResult, error) {
 		return nil, err
 	}
 
-	changes := extractResourceChanges(&plan)
+	changes := extractResourceChanges(plan.ResourceChanges)
+	driftChanges := extractResourceChanges(plan.ResourceDrift)
 
 	return &ParseResult{
 		FormatVersion: plan.FormatVersion,
 		Changes:       changes,
+		DriftChanges:  driftChanges,
+		Config:        plan.Config,
 	}, nil
 }
 
@@ -165,18 +168,19 @@ func extractMajorMinor(version string) string {
 }
 
 // extractResourceChanges converts terraform-json resource changes to our internal type.
-func extractResourceChanges(plan *tfjson.Plan) []ResourceChange {
-	if plan.ResourceChanges == nil {
+func extractResourceChanges(resourceChanges []*tfjson.ResourceChange) []ResourceChange {
+	if resourceChanges == nil {
 		return []ResourceChange{}
 	}
 
-	changes := make([]ResourceChange, 0, len(plan.ResourceChanges))
-	for _, rc := range plan.ResourceChanges {
+	changes := make([]ResourceChange, 0, len(resourceChanges))
+	for _, rc := range resourceChanges {
 		change := ResourceChange{
-			Address:      rc.Address,
-			Type:         rc.Type,
-			ProviderName: rc.ProviderName,
-			Mode:         string(rc.Mode),
+			Address:       rc.Address,
+			Type:          rc.Type,
+			ProviderName:  rc.ProviderName,
+			Mode:          string(rc.Mode),
+			ModuleAddress: rc.ModuleAddress,
 		}
 
 		if rc.Change != nil {

--- a/internal/plan/parser_test.go
+++ b/internal/plan/parser_test.go
@@ -605,6 +605,172 @@ func TestParseBinaryPlan_NoTerraform(t *testing.T) {
 	}
 }
 
+func TestParse_ModuleAddress(t *testing.T) {
+	json := `{
+		"format_version": "1.2",
+		"terraform_version": "1.9.0",
+		"resource_changes": [
+			{
+				"address": "azurerm_resource_group.root",
+				"module_address": "",
+				"mode": "managed",
+				"type": "azurerm_resource_group",
+				"name": "root",
+				"provider_name": "registry.terraform.io/hashicorp/azurerm",
+				"change": {"actions": ["create"], "before": null, "after": null}
+			},
+			{
+				"address": "module.production.azurerm_resource_group.main",
+				"module_address": "module.production",
+				"mode": "managed",
+				"type": "azurerm_resource_group",
+				"name": "main",
+				"provider_name": "registry.terraform.io/hashicorp/azurerm",
+				"change": {"actions": ["create"], "before": null, "after": null}
+			},
+			{
+				"address": "module.production.module.network.azurerm_virtual_network.main",
+				"module_address": "module.production.module.network",
+				"mode": "managed",
+				"type": "azurerm_virtual_network",
+				"name": "main",
+				"provider_name": "registry.terraform.io/hashicorp/azurerm",
+				"change": {"actions": ["create"], "before": null, "after": null}
+			}
+		]
+	}`
+	reader := strings.NewReader(json)
+	result, err := Parse(reader)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Changes) != 3 {
+		t.Fatalf("expected 3 changes, got %d", len(result.Changes))
+	}
+
+	tests := []struct {
+		address       string
+		moduleAddress string
+	}{
+		{"azurerm_resource_group.root", ""},
+		{"module.production.azurerm_resource_group.main", "module.production"},
+		{"module.production.module.network.azurerm_virtual_network.main", "module.production.module.network"},
+	}
+
+	for i, tt := range tests {
+		if result.Changes[i].Address != tt.address {
+			t.Errorf("change %d: expected address %s, got %s", i, tt.address, result.Changes[i].Address)
+		}
+		if result.Changes[i].ModuleAddress != tt.moduleAddress {
+			t.Errorf("change %d: expected module_address %q, got %q", i, tt.moduleAddress, result.Changes[i].ModuleAddress)
+		}
+	}
+}
+
+func TestParse_DriftChanges(t *testing.T) {
+	json := `{
+		"format_version": "1.2",
+		"terraform_version": "1.9.0",
+		"resource_changes": [
+			{
+				"address": "azurerm_resource_group.main",
+				"mode": "managed",
+				"type": "azurerm_resource_group",
+				"name": "main",
+				"provider_name": "registry.terraform.io/hashicorp/azurerm",
+				"change": {"actions": ["update"], "before": {"name": "old"}, "after": {"name": "new"}}
+			}
+		],
+		"resource_drift": [
+			{
+				"address": "azurerm_resource_group.main",
+				"mode": "managed",
+				"type": "azurerm_resource_group",
+				"name": "main",
+				"provider_name": "registry.terraform.io/hashicorp/azurerm",
+				"change": {"actions": ["update"], "before": {"tags": {}}, "after": {"tags": {"env": "prod"}}}
+			}
+		]
+	}`
+	reader := strings.NewReader(json)
+	result, err := Parse(reader)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Changes) != 1 {
+		t.Errorf("expected 1 change, got %d", len(result.Changes))
+	}
+	if len(result.DriftChanges) != 1 {
+		t.Fatalf("expected 1 drift change, got %d", len(result.DriftChanges))
+	}
+
+	drift := result.DriftChanges[0]
+	if drift.Address != "azurerm_resource_group.main" {
+		t.Errorf("expected drift address azurerm_resource_group.main, got %s", drift.Address)
+	}
+	if drift.Actions[0] != "update" {
+		t.Errorf("expected drift action update, got %s", drift.Actions[0])
+	}
+}
+
+func TestParse_NoDrift(t *testing.T) {
+	json := `{
+		"format_version": "1.2",
+		"terraform_version": "1.9.0",
+		"resource_changes": []
+	}`
+	reader := strings.NewReader(json)
+	result, err := Parse(reader)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.DriftChanges == nil {
+		t.Error("expected DriftChanges to be non-nil empty slice")
+	}
+	if len(result.DriftChanges) != 0 {
+		t.Errorf("expected 0 drift changes, got %d", len(result.DriftChanges))
+	}
+}
+
+func TestParse_ConfigPassthrough(t *testing.T) {
+	json := `{
+		"format_version": "1.2",
+		"terraform_version": "1.9.0",
+		"resource_changes": [],
+		"configuration": {
+			"root_module": {
+				"resources": [
+					{
+						"address": "azurerm_resource_group.main",
+						"mode": "managed",
+						"type": "azurerm_resource_group",
+						"name": "main",
+						"provider_config_key": "azurerm"
+					}
+				]
+			}
+		}
+	}`
+	reader := strings.NewReader(json)
+	result, err := Parse(reader)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Config == nil {
+		t.Fatal("expected Config to be non-nil")
+	}
+	if result.Config.RootModule == nil {
+		t.Fatal("expected Config.RootModule to be non-nil")
+	}
+	if len(result.Config.RootModule.Resources) != 1 {
+		t.Errorf("expected 1 config resource, got %d", len(result.Config.RootModule.Resources))
+	}
+}
+
 func TestParseResourceChange_ProviderName(t *testing.T) {
 	json := `{
 		"format_version": "1.2",

--- a/internal/plan/types.go
+++ b/internal/plan/types.go
@@ -1,6 +1,8 @@
 // Package plan provides Terraform plan JSON parsing functionality.
 package plan
 
+import tfjson "github.com/hashicorp/terraform-json"
+
 // ResourceChange represents a single resource change from a Terraform plan.
 type ResourceChange struct {
 	Address         string
@@ -12,10 +14,13 @@ type ResourceChange struct {
 	After           map[string]interface{}
 	BeforeSensitive map[string]interface{}
 	AfterSensitive  map[string]interface{}
+	ModuleAddress   string // e.g. "module.production.module.network", "" for root
 }
 
 // ParseResult contains the parsed plan data.
 type ParseResult struct {
 	FormatVersion string
 	Changes       []ResourceChange
+	DriftChanges  []ResourceChange // from plan.ResourceDrift
+	Config        *tfjson.Config   // full Terraform config (dependency graph)
 }

--- a/internal/plugin/loader.go
+++ b/internal/plugin/loader.go
@@ -380,5 +380,6 @@ func toSDKResourceChange(change *plan.ResourceChange) *sdk.ResourceChange {
 		After:           change.After,
 		BeforeSensitive: change.BeforeSensitive,
 		AfterSensitive:  change.AfterSensitive,
+		ModuleAddress:   change.ModuleAddress,
 	}
 }

--- a/proto/tfclassify.proto
+++ b/proto/tfclassify.proto
@@ -43,6 +43,7 @@ message ResourceChange {
     bytes after = 7;            // JSON-encoded map
     bytes before_sensitive = 8; // JSON-encoded sensitive markers
     bytes after_sensitive = 9;  // JSON-encoded sensitive markers
+    string module_address = 10; // e.g. "module.production.module.network", "" for root
 }
 
 // Decision represents a classification decision from an analyzer.

--- a/sdk/pb/tfclassify.pb.go
+++ b/sdk/pb/tfclassify.pb.go
@@ -33,6 +33,7 @@ type ResourceChange struct {
 	After           []byte                 `protobuf:"bytes,7,opt,name=after,proto3" json:"after,omitempty"`                                            // JSON-encoded map
 	BeforeSensitive []byte                 `protobuf:"bytes,8,opt,name=before_sensitive,json=beforeSensitive,proto3" json:"before_sensitive,omitempty"` // JSON-encoded sensitive markers
 	AfterSensitive  []byte                 `protobuf:"bytes,9,opt,name=after_sensitive,json=afterSensitive,proto3" json:"after_sensitive,omitempty"`    // JSON-encoded sensitive markers
+	ModuleAddress   string                 `protobuf:"bytes,10,opt,name=module_address,json=moduleAddress,proto3" json:"module_address,omitempty"`      // e.g. "module.production.module.network", "" for root
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -128,6 +129,13 @@ func (x *ResourceChange) GetAfterSensitive() []byte {
 		return x.AfterSensitive
 	}
 	return nil
+}
+
+func (x *ResourceChange) GetModuleAddress() string {
+	if x != nil {
+		return x.ModuleAddress
+	}
+	return ""
 }
 
 // Decision represents a classification decision from an analyzer.
@@ -928,7 +936,7 @@ var File_proto_tfclassify_proto protoreflect.FileDescriptor
 const file_proto_tfclassify_proto_rawDesc = "" +
 	"\n" +
 	"\x16proto/tfclassify.proto\x12\n" +
-	"tfclassify\"\x93\x02\n" +
+	"tfclassify\"\xba\x02\n" +
 	"\x0eResourceChange\x12\x18\n" +
 	"\aaddress\x18\x01 \x01(\tR\aaddress\x12\x12\n" +
 	"\x04type\x18\x02 \x01(\tR\x04type\x12#\n" +
@@ -938,7 +946,9 @@ const file_proto_tfclassify_proto_rawDesc = "" +
 	"\x06before\x18\x06 \x01(\fR\x06before\x12\x14\n" +
 	"\x05after\x18\a \x01(\fR\x05after\x12)\n" +
 	"\x10before_sensitive\x18\b \x01(\fR\x0fbeforeSensitive\x12'\n" +
-	"\x0fafter_sensitive\x18\t \x01(\fR\x0eafterSensitive\"\x82\x01\n" +
+	"\x0fafter_sensitive\x18\t \x01(\fR\x0eafterSensitive\x12%\n" +
+	"\x0emodule_address\x18\n" +
+	" \x01(\tR\rmoduleAddress\"\x82\x01\n" +
 	"\bDecision\x12&\n" +
 	"\x0eclassification\x18\x01 \x01(\tR\x0eclassification\x12\x16\n" +
 	"\x06reason\x18\x02 \x01(\tR\x06reason\x12\x1a\n" +

--- a/sdk/plugin/grpc.go
+++ b/sdk/plugin/grpc.go
@@ -255,6 +255,7 @@ func ProtoToSDKResourceChange(p *pb.ResourceChange) (*sdk.ResourceChange, error)
 		After:           after,
 		BeforeSensitive: beforeSensitive,
 		AfterSensitive:  afterSensitive,
+		ModuleAddress:   p.ModuleAddress,
 	}, nil
 }
 
@@ -302,6 +303,7 @@ func SDKToProtoResourceChange(s *sdk.ResourceChange) (*pb.ResourceChange, error)
 		After:           after,
 		BeforeSensitive: beforeSensitive,
 		AfterSensitive:  afterSensitive,
+		ModuleAddress:   s.ModuleAddress,
 	}, nil
 }
 

--- a/sdk/types.go
+++ b/sdk/types.go
@@ -15,6 +15,7 @@ type ResourceChange struct {
 	After           map[string]interface{}
 	BeforeSensitive map[string]interface{}
 	AfterSensitive  map[string]interface{}
+	ModuleAddress   string // e.g. "module.production.module.network", "" for root
 }
 
 // Decision represents a classification decision from a plugin analyzer.

--- a/testdata/e2e/module-scoped-rules/.tfclassify.hcl
+++ b/testdata/e2e/module-scoped-rules/.tfclassify.hcl
@@ -1,0 +1,38 @@
+# Module-scoped rules: classify deletions inside module.network as critical,
+# while the same deletion at root level stays standard.
+
+classification "critical" {
+  description = "Critical - module-scoped deletion"
+
+  rule {
+    description = "Deleting resources inside the network module requires approval"
+    module      = ["module.network"]
+    resource    = ["*"]
+    actions     = ["delete"]
+  }
+}
+
+classification "standard" {
+  description = "Standard change"
+
+  rule {
+    resource = ["*"]
+  }
+}
+
+classification "auto" {
+  description = "Auto-approved"
+
+  rule {
+    resource = ["*"]
+    actions  = ["no-op"]
+  }
+}
+
+precedence = ["critical", "standard", "auto"]
+
+defaults {
+  unclassified   = "standard"
+  no_changes     = "auto"
+  plugin_timeout = "30s"
+}

--- a/testdata/e2e/module-scoped-rules/expected.json
+++ b/testdata/e2e/module-scoped-rules/expected.json
@@ -1,0 +1,4 @@
+{
+  "create": { "exit_code": 1, "classification": "standard" },
+  "destroy": { "exit_code": 2, "classification": "critical" }
+}

--- a/testdata/e2e/module-scoped-rules/main.tf
+++ b/testdata/e2e/module-scoped-rules/main.tf
@@ -1,0 +1,44 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+  resource_provider_registrations = "none"
+}
+
+resource "random_id" "suffix" {
+  byte_length = 4
+}
+
+variable "resource_group_name" {}
+
+data "azurerm_resource_group" "lab" {
+  name = var.resource_group_name
+}
+
+# Root-module resource — should be classified as "standard"
+resource "azurerm_route_table" "root" {
+  name                = "rt-root-${random_id.suffix.hex}"
+  resource_group_name = data.azurerm_resource_group.lab.name
+  location            = data.azurerm_resource_group.lab.location
+}
+
+# Module resources — deletion should be classified as "critical"
+# via the module-scoped rule
+module "network" {
+  source = "./modules/network"
+
+  name_suffix         = random_id.suffix.hex
+  resource_group_name = data.azurerm_resource_group.lab.name
+  location            = data.azurerm_resource_group.lab.location
+}

--- a/testdata/e2e/module-scoped-rules/modules/network/main.tf
+++ b/testdata/e2e/module-scoped-rules/modules/network/main.tf
@@ -1,0 +1,15 @@
+variable "name_suffix" {}
+variable "resource_group_name" {}
+variable "location" {}
+
+resource "azurerm_network_security_group" "this" {
+  name                = "nsg-modscope-${var.name_suffix}"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+}
+
+resource "azurerm_route_table" "this" {
+  name                = "rt-modscope-${var.name_suffix}"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+}

--- a/testdata/e2e/topology/.tfclassify.hcl
+++ b/testdata/e2e/topology/.tfclassify.hcl
@@ -1,0 +1,37 @@
+# Topology: flag resources whose change propagates to many downstream dependents.
+# The vnet has downstream: subnet and nsg_association (2 dependents), exceeding
+# the max_downstream=1 threshold → critical.
+
+classification "critical" {
+  description = "Topology threshold exceeded"
+
+  topology {
+    max_downstream        = 1
+    max_propagation_depth = 1
+  }
+}
+
+classification "standard" {
+  description = "Standard change"
+
+  rule {
+    resource = ["*"]
+  }
+}
+
+classification "auto" {
+  description = "Auto-approved"
+
+  rule {
+    resource = ["*"]
+    actions  = ["no-op"]
+  }
+}
+
+precedence = ["critical", "standard", "auto"]
+
+defaults {
+  unclassified   = "standard"
+  no_changes     = "auto"
+  plugin_timeout = "30s"
+}

--- a/testdata/e2e/topology/expected.json
+++ b/testdata/e2e/topology/expected.json
@@ -1,0 +1,4 @@
+{
+  "create": { "exit_code": 2, "classification": "critical" },
+  "destroy": { "exit_code": 2, "classification": "critical" }
+}

--- a/testdata/e2e/topology/main.tf
+++ b/testdata/e2e/topology/main.tf
@@ -1,0 +1,56 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+  resource_provider_registrations = "none"
+}
+
+resource "random_id" "suffix" {
+  byte_length = 4
+}
+
+variable "resource_group_name" {}
+
+data "azurerm_resource_group" "lab" {
+  name = var.resource_group_name
+}
+
+# Dependency chain: vnet → subnet → nsg_association
+# vnet has 2 downstream resources (subnet + nsg_association via subnet),
+# exceeding the max_downstream=1 threshold.
+
+resource "azurerm_virtual_network" "main" {
+  name                = "vnet-topo-${random_id.suffix.hex}"
+  resource_group_name = data.azurerm_resource_group.lab.name
+  location            = data.azurerm_resource_group.lab.location
+  address_space       = ["10.200.0.0/16"]
+}
+
+resource "azurerm_network_security_group" "main" {
+  name                = "nsg-topo-${random_id.suffix.hex}"
+  resource_group_name = data.azurerm_resource_group.lab.name
+  location            = data.azurerm_resource_group.lab.location
+}
+
+resource "azurerm_subnet" "main" {
+  name                 = "subnet-topo"
+  resource_group_name  = data.azurerm_resource_group.lab.name
+  virtual_network_name = azurerm_virtual_network.main.name
+  address_prefixes     = ["10.200.1.0/24"]
+}
+
+resource "azurerm_subnet_network_security_group_association" "main" {
+  subnet_id                 = azurerm_subnet.main.id
+  network_security_group_id = azurerm_network_security_group.main.id
+}


### PR DESCRIPTION
## Summary

Adds three cross-provider, plan-level features that bring depth to the base offering by leveraging rich data already present in Terraform plans (dependency graph, drift metadata, module paths).

- **Enriched plan parsing** — foundation for all three features: extracts `ModuleAddress`, `DriftChanges`, and `Config` (dependency graph) from Terraform plans. Updates protobuf schema and SDK types.
- **Module-scoped rules** — new `module` and `not_module` fields on classification rules, allowing rules to target specific Terraform module paths with glob patterns (`*` = one level, `**` = any depth)
- **Drift vs intent separation** — new `drift_classification` default and `exclude_drift` blast radius option to separate drift corrections from intentional changes in approval workflows
- **Change topology** — graph-aware blast radius using the Terraform dependency graph. New `topology` block per classification with `max_downstream` and `max_propagation_depth` thresholds

### New builtin analyzers

| Analyzer | Interface | Purpose |
|----------|-----------|---------|
| `drift` | `PlanAwareAnalyzer` | Classifies drift-corrected resources separately |
| `topology` | `PlanAwareAnalyzer` | Flags resources whose changes propagate beyond configured thresholds |

### New config fields

```hcl
classification "critical" {
  rule {
    module   = ["module.production", "module.production.**"]
    resource = ["*"]
    actions  = ["delete"]
  }
  blast_radius {
    exclude_drift = true
  }
  topology {
    max_downstream        = 10
    max_propagation_depth = 3
  }
}

defaults {
  drift_classification = "standard"
}
```

### E2E coverage

- `module-scoped-rules` — validates module-level rule filtering against real Azure infrastructure
- `topology` — validates dependency graph analysis with VNet → Subnet → NSG chain

## Test plan

- [x] `make ci` passes (build, test, vet, lint, govulncheck)
- [x] All 16 e2e scenarios pass with `--build --plan-only`
- [x] Full-reference example validates with `tfclassify validate`
- [x] Existing e2e scenarios unchanged (backward compatible)
- [x] New unit tests cover module matching, drift analysis, topology graph building, and threshold evaluation
- [x] Documentation updated: README, CLAUDE.md, full-reference example

🤖 Generated with [Claude Code](https://claude.com/claude-code)