### PR TITLE
feat: scoped ignore attributes

### DIFF
--- a/cmd/tfclassify/main.go
+++ b/cmd/tfclassify/main.go
@@ -164,9 +164,11 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Preprocess: downgrade cosmetic-only updates (e.g., tag-only changes) to no-op
-	if cfg.Defaults != nil && len(cfg.Defaults.IgnoreAttributes) > 0 {
-		classify.FilterCosmeticChanges(planResult.Changes, cfg.Defaults.IgnoreAttributes)
+	ignoreRules, err := classify.CompileIgnoreRules(cfg.Defaults)
+	if err != nil {
+		return fmt.Errorf("failed to compile ignore rules: %w", err)
 	}
+	classify.FilterCosmeticChanges(planResult.Changes, ignoreRules)
 
 	// Create classifier
 	classifier, err := classify.New(cfg)
@@ -326,9 +328,11 @@ func runExplain(cmd *cobra.Command, args []string) error {
 	}
 
 	// Preprocess: downgrade cosmetic-only updates (e.g., tag-only changes) to no-op
-	if cfg.Defaults != nil && len(cfg.Defaults.IgnoreAttributes) > 0 {
-		classify.FilterCosmeticChanges(planResult.Changes, cfg.Defaults.IgnoreAttributes)
+	ignoreRules, err := classify.CompileIgnoreRules(cfg.Defaults)
+	if err != nil {
+		return fmt.Errorf("failed to compile ignore rules: %w", err)
 	}
+	classify.FilterCosmeticChanges(planResult.Changes, ignoreRules)
 
 	// Create classifier
 	classifier, err := classify.New(cfg)

--- a/docs/cr/CR-0035-scoped-ignore-attributes.md
+++ b/docs/cr/CR-0035-scoped-ignore-attributes.md
@@ -1,0 +1,461 @@
+---
+id: "CR-0035"
+status: "proposed"
+date: 2026-04-21
+requestor: Johan Karlsson
+stakeholders:
+  - Johan Karlsson
+priority: "high"
+target-version: "0.8.0"
+---
+
+# Scoped Ignore Attributes: Per-Resource-Type Ignore Rules with Attribute-Path Globs
+
+## Change Summary
+
+CR-0034 introduced `ignore_attributes` as a flat global list attached to the `defaults {}` block. Real-world plans show that this scope is too coarse: providers such as `azapi` expose computed attributes (notably `output`) that change from a populated map to `(known after apply)` on every refresh, and the only way to neutralise them today is to add the attribute globally — which silently affects every resource type that happens to use the same name. This CR extends the mechanism with a new repeatable `ignore_attribute "name" { … }` block that scopes an ignore rule to specific `resource` / `module` globs, and upgrades attribute-path matching from bare prefixes to per-segment globs (e.g. `properties.*.createdAt`).
+
+## Motivation and Background
+
+Since CR-0034 shipped, an operational gap has emerged: users cannot express "ignore attribute X **only** on resource type Y." Two concrete cases drive this:
+
+1. **`azapi_resource.output` refresh noise.** The `azapi` provider stores the full API response in the `output` attribute. Every plan shows this attribute diffing from the previously observed map to `(known after apply)`, producing hundreds of lines of `Before`/`After` churn that is not a user-authored change. Adding `output` to the global list solves the noise but silently hides `output` on every other resource type where it may carry real meaning.
+
+2. **Wildcarded attribute paths.** Several providers store lists of objects under a single attribute (e.g. `properties.rules[*].createdAt`, `spec.*.tags`). Today's prefix matcher cannot target these — users would have to enumerate every known key or widen the ignore to the root of the attribute, which sacrifices precision.
+
+The underlying CR-0034 design already records `OriginalActions` and `IgnoredAttributes` on the change, so the aggregation and output machinery does not need to change. What needs to change is (a) how ignore rules are declared, (b) how attribute paths are matched, and (c) how rule attribution (rule name + description) is surfaced when a downgrade happens.
+
+## Change Drivers
+
+* `azapi` (and other dynamic-provider) refresh noise blocks adoption of `ignore_attributes` for teams using provider-agnostic resource definitions
+* Per-resource-type precision was explicitly deferred as "out of scope" in CR-0034; usage data now justifies building it
+* Attribute-path wildcards are required to express nested/indexed ignores without sprawling enumerations
+* Audit consumers need to attribute a downgrade to a *named, described* rule — today they see only the attribute paths
+
+## Current State
+
+`ignore_attributes` is a single flat `[]string` on `DefaultsConfig` (`internal/config/config.go:176`):
+
+```hcl
+defaults {
+  ignore_attributes = ["tags", "tags_all"]
+}
+```
+
+The preprocessing pass lives in `internal/classify/attribute_filter.go:17` (`FilterCosmeticChanges`):
+
+* Iterates every `["update"]` resource.
+* Diffs `Before` / `After` maps.
+* Uses `isPathCovered` (line 123) — a **bare-prefix** matcher that accepts `"tags"` → `tags`, `tags.env`, `tags.env.team`, but cannot express `properties.*.createdAt`.
+* Applies the same list to every resource — there is no `resource` / `module` filter.
+
+When every changed attribute is covered, the pass rewrites `Actions` to `["no-op"]` and records `OriginalActions` + `IgnoredAttributes` on the change (`internal/plan/types.go:19-24`). Output formatters already print both.
+
+### Current State Diagram
+
+```mermaid
+flowchart LR
+    subgraph Current["Current: CR-0034 global ignore_attributes"]
+        Cfg["defaults { ignore_attributes = [...] }"] --> Filter["FilterCosmeticChanges<br/>bare-prefix match"]
+        Plan["Plan changes"] --> Filter
+        Filter -->|"covered: downgrade"| NoOp["actions: [no-op]"]
+        Filter -->|"uncovered: keep"| Keep["actions: [update]"]
+    end
+```
+
+## Proposed Change
+
+Add a new repeatable `ignore_attribute "name" { … }` block inside `defaults {}`. The block carries its own description, resource/module filter, and attribute list. The existing `ignore_attributes = [...]` list remains supported unchanged and is treated as the always-on "unscoped" rule set. Both forms are additive: the effective ignore set for a given resource is the union of the global list and every scoped rule whose resource/module globs match.
+
+Attribute matching is upgraded from bare prefixes to **per-segment globs**. An entry is split on `.` and each segment is compiled with `github.com/gobwas/glob` (already a dependency via `internal/classify/matchers`). A concrete path matches when its segment count is ≥ the pattern's segment count and every corresponding segment matches the compiled glob. A pattern with fewer segments than the path implicitly covers any deeper path — this preserves CR-0034's prefix semantics: `"tags"` still covers `tags.env.team`.
+
+When a downgrade is driven by a named scoped rule, the rule's `name` and `description` are recorded on the change so explain/SARIF/evidence output can attribute the downgrade without the reader cross-referencing the config.
+
+### Proposed State Diagram
+
+```mermaid
+flowchart LR
+    subgraph Proposed["Proposed: CR-0035 scoped ignore_attribute"]
+        Global["defaults { ignore_attributes = [...] }"] --> Merge["Effective rule set<br/>per resource"]
+        Scoped["defaults { ignore_attribute 'N' {...} }"] --> Merge
+        Plan["Plan changes"] --> Filter["FilterCosmeticChanges<br/>per-segment glob match"]
+        Merge --> Filter
+        Filter -->|"covered: downgrade"| NoOp["actions: [no-op]<br/>+ rule name + description"]
+        Filter -->|"uncovered: keep"| Keep["actions: [update]"]
+    end
+```
+
+### Target Grammar
+
+```hcl
+defaults {
+  # Unchanged: global, always-on list (CR-0034)
+  ignore_attributes = ["tags", "tags_all"]
+
+  # New: scoped rule with required description and resource filter
+  ignore_attribute "azapi_output" {
+    description = "azapi_resource.output is a computed read-back of the API response; not a user-authored change."
+    resource    = "azapi_resource"
+    attributes  = ["output"]
+  }
+
+  ignore_attribute "diag_setting_dedicated" {
+    description = "Legacy -> Dedicated destination type toggle; treated as cosmetic per platform policy."
+    resource    = "azurerm_monitor_diagnostic_setting"
+    attributes  = ["log_analytics_destination_type"]
+  }
+
+  ignore_attribute "transient_timestamps" {
+    description = "API-assigned timestamps nested inside properties on azapi resources."
+    resource    = "azapi_*"
+    attributes  = ["properties.*.createdAt", "properties.*.updatedAt"]
+  }
+}
+```
+
+## Requirements
+
+### Functional Requirements
+
+1. The system **MUST** accept a repeatable `ignore_attribute "name" { … }` block inside `defaults {}`.
+2. The system **MUST** reject configuration where two `ignore_attribute` blocks share the same `name` label.
+3. The system **MUST** require a non-empty `description` string on every `ignore_attribute` block.
+4. The system **MUST** require a non-empty `attributes` list on every `ignore_attribute` block and reject any empty entry.
+5. The system **MUST** accept `resource`, `not_resource`, `module`, and `not_module` lists on an `ignore_attribute` block, each using the same glob semantics as existing `rule {}` blocks (`internal/classify/matchers`).
+6. The system **MUST** compile every `attributes` entry into per-segment globs using `github.com/gobwas/glob` and reject entries that fail to compile.
+7. The system **MUST** preserve existing bare-prefix semantics: an attribute entry `"tags"` (one segment) **MUST** match `tags`, `tags.env`, and `tags.env.team`.
+8. The system **MUST** match a multi-segment attribute pattern against a concrete path if and only if every pattern segment matches the corresponding path segment using the compiled glob, and the pattern does not have more segments than the path.
+9. The system **MUST** compute, for each updated resource, the effective ignore set as the union of `defaults.ignore_attributes` and every scoped `ignore_attribute` whose `resource`/`not_resource`/`module`/`not_module` filter matches the resource.
+10. The system **MUST** continue to evaluate only `["update"]` actions for cosmetic downgrade; `create`, `delete`, `replace`, and `read` **MUST** be left unmodified.
+11. The system **MUST** record the set of matching scoped rule names and descriptions on the downgraded change, in addition to the existing `OriginalActions` and `IgnoredAttributes` fields.
+12. The text, JSON, SARIF, GitHub Actions, explain, and evidence output **MUST** include the matched rule names and descriptions when a scoped rule contributed to the downgrade.
+13. The system **MUST** keep the existing `defaults.ignore_attributes = [...]` flat list working unchanged when no scoped blocks are present.
+14. The system **MUST** allow a resource to be downgraded when its changed attribute paths are collectively covered by the union of global and scoped entries — a scoped rule need not cover every path on its own.
+
+### Non-Functional Requirements
+
+1. The filter **MUST** compile globs once per config load, not per resource, to keep per-plan overhead at O(resources × changed-paths × matchers).
+2. The filter **MUST** short-circuit on the first uncovered changed attribute (existing behaviour in `hasOnlyIgnoredChanges`).
+3. Configuration parsing **MUST** fail fast with an actionable error message that names the offending block, field, and line number (via HCL diagnostics) when validation fails.
+
+## Affected Components
+
+* `internal/config/config.go` — schema additions (`IgnoreAttributeRule`, field on `DefaultsConfig`).
+* `internal/config/validation.go` — extend `validateIgnoreAttributes` to cover the new block.
+* `internal/classify/attribute_filter.go` — per-segment glob matcher, scoped-rule evaluation, rule-attribution recording.
+* `internal/classify/matchers.go` — reuse the existing glob-compile helpers for `resource` / `module`.
+* `internal/plan/types.go` — add a small `IgnoreRuleMatches` field recording matched scoped rules.
+* `internal/output/formatter.go`, `explain.go`, `sarif.go`, `github_action.go`, `evidence.go` — render rule name + description next to ignored-attribute paths.
+* `cmd/tfclassify/main.go` — pass the full defaults (or a precomputed matcher) into `FilterCosmeticChanges`.
+* `docs/examples/full-reference/.tfclassify.hcl` — add a worked example of the new block.
+* `internal/scaffold/generate.go` — extend the scaffold template comment.
+* `testdata/e2e/` — extend the existing `ignore_attributes` fixture (or add a sibling scenario) covering the scoped + glob paths.
+
+## Scope Boundaries
+
+### In Scope
+
+* Repeatable `ignore_attribute "name" { description, resource, not_resource, module, not_module, attributes }` block under `defaults {}`.
+* Per-segment attribute-path globs via `gobwas/glob` (segment-level `*` and `?`).
+* Backwards-compatible `ignore_attributes = [...]` (CR-0034) — kept unchanged.
+* Attribution of matched scoped rules in all existing output formats.
+* Validation errors for empty/duplicate/uncompilable input.
+
+### Out of Scope ("Here, But Not Further")
+
+* **Recursive `**` globs** that match across arbitrary depth. Segment-level wildcards are sufficient for the driving use cases and keep matching predictable and O(n·m).
+* **Provider-aware auto-detection** of computed attributes (e.g. autodiscovering that `azapi_resource.output` is computed). Users name the attribute explicitly.
+* **Per-classification scoping** (placing `ignore_attribute` inside a `classification {}` block). Keeping the block on `defaults {}` preserves the "preprocessing" semantics — downgrades happen before classification, so scoping by classification would create ordering ambiguity.
+* **Regex matching** for attribute paths. Globs are sufficient; regex adds complexity and user error modes.
+* **Wildcarding actions** (e.g. ignoring tags on deletions). CR-0034 deliberately limited this to `["update"]` and CR-0035 preserves that boundary.
+
+## Alternative Approaches Considered
+
+* **Widen the global list.** Add `"output"` to `ignore_attributes`. Rejected — silently hides `output` on every provider that uses the name, which violates the precision the CR is trying to deliver.
+* **Per-classification `ignore_attribute`.** Move the block into `classification {}`. Rejected — preprocessing runs before classification, so scoping to a classification name requires duplicating the classifier's resource/module matcher at filter time, and creates ordering confusion.
+* **Runtime detection of computed attributes.** Inspect provider schema to auto-skip computed fields. Rejected — requires shipping schema data for every provider and introduces provider-version coupling.
+* **Full regex.** Use `regexp` for attribute paths. Rejected — globs match the existing resource-matching semantics in the codebase and are easier for users to write correctly.
+
+## Impact Assessment
+
+### User Impact
+
+Users who are happy with today's `ignore_attributes = [...]` need no changes. Users hitting the `azapi.output` problem gain a precise tool: one block per provider quirk, with a description that explains *why* the attribute is being ignored. Audit consumers gain rule-level attribution in all output formats.
+
+### Technical Impact
+
+* No breaking changes. The new block is additive; existing configs keep working.
+* Config schema gains one field on `DefaultsConfig` and one struct (`IgnoreAttributeRule`).
+* The filter's matcher is rewritten from byte-prefix to segment-glob. Behaviour for single-segment entries is identical — verified by an explicit regression test.
+* `plan.ResourceChange` gains one new field (`IgnoreRuleMatches`). Output formatters add one new row of metadata per downgraded resource.
+* Config-load time grows by O(number of ignore_attribute blocks × number of attribute patterns × number of segments). Negligible in practice.
+
+### Business Impact
+
+Removes the primary blocker for adopting `ignore_attributes` on plans that include dynamic-provider resources (notably `azapi`). Enables correct `auto`/`standard` routing for module version bumps in environments where every module touches an `azapi_resource`.
+
+## Implementation Approach
+
+Phase 1 — Config & validation:
+
+1. Add `IgnoreAttributeRule` struct with `Name`, `Description`, `Resource`, `NotResource`, `Module`, `NotModule`, `Attributes`.
+2. Add `IgnoreAttributeRules []IgnoreAttributeRule` on `DefaultsConfig` with `hcl:"ignore_attribute,block"`.
+3. Extend `validateIgnoreAttributes` to enforce non-empty description, non-empty attributes, unique names, and compilable globs.
+
+Phase 2 — Matcher & filter:
+
+4. Introduce a `pathPattern` type holding a compiled `[]glob.Glob` per segment and a `coverage(path string) bool` method.
+5. Replace `isPathCovered` with a call that evaluates a slice of `pathPattern`. Keep bare-prefix semantics explicit in the implementation so regressions are obvious.
+6. Rework `FilterCosmeticChanges` signature to accept the full defaults (or a precomputed `IgnoreMatcher`). For each update resource, build the effective pattern set.
+7. Record `IgnoreRuleMatches` on the change.
+
+Phase 3 — Output & wiring:
+
+8. Update `cmd/tfclassify/main.go:167,329` to pass the new matcher.
+9. Update every output formatter to render rule name + description alongside the existing ignored-attribute paths.
+10. Update scaffold + full-reference docs.
+
+Phase 4 — Tests:
+
+11. Unit tests for `pathPattern` matcher covering all acceptance criteria.
+12. Integration tests exercising `FilterCosmeticChanges` with combined global + scoped rules.
+13. E2E fixture extension (or new scenario) covering the real-world plan shape: tag-only resources, azapi with computed output, diagnostic_setting with a genuine attribute add.
+
+### Implementation Flow
+
+```mermaid
+flowchart LR
+    subgraph Phase1["Phase 1: Config"]
+        A1[Struct + field] --> A2[Validation]
+    end
+    subgraph Phase2["Phase 2: Filter"]
+        B1[pathPattern type] --> B2[Effective set] --> B3[Rule attribution]
+    end
+    subgraph Phase3["Phase 3: Output"]
+        C1[main.go wiring] --> C2[Formatters]
+    end
+    subgraph Phase4["Phase 4: Tests"]
+        D1[Unit] --> D2[Integration] --> D3[E2E]
+    end
+    Phase1 --> Phase2 --> Phase3 --> Phase4
+```
+
+## Test Strategy
+
+### Tests to Add
+
+| Test File | Test Name | Description | Inputs | Expected Output |
+|-----------|-----------|-------------|--------|-----------------|
+| `internal/classify/attribute_filter_test.go` | `TestFilter_ScopedRuleMatches` | Scoped rule on `azapi_resource` downgrades the matching resource only | Two updates: `azapi_resource` (tags + output), `azurerm_storage_account` (tags + output); config: global `ignore_attributes=["tags"]` + scoped `{resource="azapi_resource", attributes=["output"]}` | azapi actions → `["no-op"]`; storage actions unchanged |
+| `internal/classify/attribute_filter_test.go` | `TestFilter_PathGlob_TailWildcard` | `tags.temp_*` covers `tags.temp_foo` but not `tags.keep` | Update with `Before.tags.temp_x != After.tags.temp_x` | downgrade; `IgnoredAttributes = ["tags.temp_x"]` |
+| `internal/classify/attribute_filter_test.go` | `TestFilter_PathGlob_MidWildcard` | `properties.*.tags` covers `properties.rule1.tags` and `properties.rule2.tags` but not `properties.tags` | Nested changed maps | downgrade only when every change sits under a wildcard slot |
+| `internal/classify/attribute_filter_test.go` | `TestFilter_PathGlob_LeadingWildcard` | `*.tags` covers `meta.tags` and `spec.tags` | Two changed leaf paths in separate top-level maps | both covered → downgrade |
+| `internal/classify/attribute_filter_test.go` | `TestFilter_BarePrefixBackCompat` | `tags` still covers `tags.env.team` after the globber rewrite | Nested three-level path change | downgrade |
+| `internal/classify/attribute_filter_test.go` | `TestFilter_RuleAttribution` | Matched rule name + description recorded on the change | Single scoped rule matches | `IgnoreRuleMatches[0].Name == "azapi_output"`, `.Description == "..."` |
+| `internal/classify/attribute_filter_test.go` | `TestFilter_UnionGlobalAndScoped` | A resource whose changes span both global and scoped patterns is downgraded | Changed `tags.env` (global) + `output.x` (scoped) on an `azapi_resource` | downgrade; both paths recorded |
+| `internal/config/validation_test.go` | `TestValidate_IgnoreAttributeRule_MissingDescription` | Reject empty description | `ignore_attribute "n" { attributes = ["x"] }` | error mentions `description` |
+| `internal/config/validation_test.go` | `TestValidate_IgnoreAttributeRule_EmptyAttributes` | Reject empty attributes list / entry | `attributes = []` and `attributes = [""]` | error mentions `attributes` |
+| `internal/config/validation_test.go` | `TestValidate_IgnoreAttributeRule_DuplicateName` | Reject duplicate block names | Two blocks labelled `"x"` | error mentions duplicate |
+| `internal/config/validation_test.go` | `TestValidate_IgnoreAttributeRule_InvalidGlob` | Reject uncompilable attribute glob | `attributes = ["["]` | error mentions invalid glob |
+| `testdata/e2e/ignore-attributes/` (existing) | fixture update | Extend the fixture with an azapi-like resource + scoped rule | Plan JSON + `.tfclassify.hcl` | `expected.json` shows scoped downgrade |
+
+### Tests to Modify
+
+| Test File | Test Name | Current Behavior | New Behavior | Reason for Change |
+|-----------|-----------|------------------|--------------|-------------------|
+| `internal/classify/attribute_filter_test.go` | existing `isPathCovered` tests | Prefix-only | Call through the new matcher with the same assertions | Ensure CR-0034 semantics preserved after rewrite |
+| `internal/config/validation_test.go` | `TestValidate_IgnoreAttributesValid` | Only checks flat list | Extend fixture to also include one scoped block parsing cleanly | Prove the two forms coexist |
+
+### Tests to Remove
+
+| Test File | Test Name | Reason for Removal |
+|-----------|-----------|-------------------|
+| _(none)_ | _(none)_ | No functionality is being removed; CR-0034 tests remain valid |
+
+## Acceptance Criteria
+
+### AC-1: Scoped rule downgrades matching resource only
+
+```gherkin
+Given a config with global "ignore_attributes = [\"tags\"]"
+  And an "ignore_attribute \"azapi_output\"" block with "resource = \"azapi_resource\"" and "attributes = [\"output\"]"
+  And a plan containing an "azapi_resource" update that changes tags and output
+  And a plan containing an "azurerm_storage_account" update that changes tags and output
+When tfclassify preprocesses the plan
+Then the azapi_resource actions are rewritten to ["no-op"]
+  And the azurerm_storage_account actions remain ["update"]
+```
+
+### AC-2: Non-matching resource is unchanged
+
+```gherkin
+Given a scoped ignore_attribute block with "resource = \"azapi_resource\""
+When a plan contains an azurerm_key_vault update covered only by the scoped rule's attributes
+Then the azurerm_key_vault actions remain ["update"]
+  And no IgnoredAttributes are recorded on the change
+```
+
+### AC-3: Mid-path glob matches nested keys but not the parent
+
+```gherkin
+Given an attribute entry "properties.*.createdAt"
+When a resource has a changed path "properties.rule1.createdAt"
+Then the pattern MUST cover the path
+When a resource has a changed path "properties.createdAt"
+Then the pattern MUST NOT cover the path
+```
+
+### AC-4: Bare prefix preserves CR-0034 semantics
+
+```gherkin
+Given an attribute entry "tags"
+When a resource has a changed path "tags.env.team"
+Then the pattern MUST cover the path
+```
+
+### AC-5: Global list continues to work
+
+```gherkin
+Given a config with only "ignore_attributes = [\"tags\"]" and no scoped blocks
+When a plan contains a resource whose only change is "tags.env"
+Then the resource actions are rewritten to ["no-op"]
+  And IgnoreRuleMatches is empty
+```
+
+### AC-6: Validation rejects malformed blocks
+
+```gherkin
+Given an ignore_attribute block missing description
+When tfclassify loads the config
+Then loading MUST fail with an error naming "description"
+Given an ignore_attribute block with an empty attributes list
+When tfclassify loads the config
+Then loading MUST fail with an error naming "attributes"
+Given two ignore_attribute blocks with the same label
+When tfclassify loads the config
+Then loading MUST fail with an error naming the duplicate label
+Given an ignore_attribute entry "["
+When tfclassify loads the config
+Then loading MUST fail with an error naming the invalid glob
+```
+
+### AC-7: Rule attribution surfaces in output
+
+```gherkin
+Given a scoped rule "azapi_output" with description "computed read-back"
+When the rule contributes to a downgrade
+Then the change's IgnoreRuleMatches MUST contain {name: "azapi_output", description: "computed read-back"}
+  And the explain, SARIF, JSON, text, and evidence outputs MUST print both fields
+```
+
+### AC-8: Union of global and scoped rules covers a resource
+
+```gherkin
+Given a global list "ignore_attributes = [\"tags\"]"
+  And a scoped rule on "azapi_resource" with "attributes = [\"output\"]"
+  And an azapi_resource with changed paths "tags.env" and "output.id"
+When tfclassify preprocesses the plan
+Then the resource actions are rewritten to ["no-op"]
+  And IgnoredAttributes contains both paths
+  And IgnoreRuleMatches contains the azapi_output rule
+```
+
+## Quality Standards Compliance
+
+### Build & Compilation
+
+- [ ] `make build-all` succeeds
+- [ ] No new compiler warnings introduced
+
+### Linting & Code Style
+
+- [ ] `make lint` passes
+- [ ] `make vet` passes
+- [ ] New code follows existing patterns in `internal/classify/matchers.go`
+
+### Test Execution
+
+- [ ] `make test` passes
+- [ ] New unit tests cover every acceptance criterion
+- [ ] E2E fixture extension passes under `bash testdata/e2e/run.sh --build --fixtures`
+
+### Documentation
+
+- [ ] `docs/examples/full-reference/.tfclassify.hcl` documents the scoped block
+- [ ] `internal/scaffold/generate.go` template mentions the scoped block as an optional extension
+- [ ] CR-0034 and README cross-references remain accurate
+
+### Code Review
+
+- [ ] PR title uses Conventional Commits (`feat(config): scope ignore_attributes to resource globs`)
+- [ ] Squash merge to preserve linear history
+
+### Verification Commands
+
+```bash
+make build-all
+make ci
+bash testdata/e2e/run.sh --build --fixtures
+```
+
+## Risks and Mitigation
+
+### Risk 1: Breaking CR-0034 semantics during the matcher rewrite
+
+**Likelihood:** medium
+**Impact:** high
+**Mitigation:** Keep single-segment prefix semantics explicit in a named branch of the matcher. Retain every CR-0034 test plus a dedicated `TestFilter_BarePrefixBackCompat` case (AC-4). Run the existing `ignore_attributes` e2e fixture unchanged as a regression guard.
+
+### Risk 2: Glob compile-time errors surfacing at classify-time instead of load-time
+
+**Likelihood:** low
+**Impact:** medium
+**Mitigation:** Compile every attribute entry during config validation. Any compile failure surfaces with an HCL diagnostic pointing at the file/line, before any plan is parsed.
+
+### Risk 3: User confusion between the flat list and the scoped block
+
+**Likelihood:** medium
+**Impact:** low
+**Mitigation:** Documentation clearly separates the two in `docs/examples/full-reference/.tfclassify.hcl`. Scaffolded config keeps the flat list as the default and mentions the scoped block as an advanced option.
+
+### Risk 4: Silent "union of ignore rules covers everything" hiding a real change
+
+**Likelihood:** low
+**Impact:** medium
+**Mitigation:** Downgrade reasons are always visible in output (text/JSON/SARIF/explain/evidence) with the rule name + description that caused the downgrade. Users reviewing a PR can see exactly which rule neutralised which attribute.
+
+## Dependencies
+
+* CR-0034 (`ignore_attributes`) — this CR extends the same mechanism and reuses `FilterCosmeticChanges`, `IgnoredAttributes`, and `OriginalActions`.
+* `github.com/gobwas/glob` — already a repo dependency via `internal/classify/matchers`.
+
+## Estimated Effort
+
+* Config + validation: ~3 h
+* Matcher + filter rewrite: ~5 h
+* Output wiring (6 formatters): ~2 h
+* Tests (unit + integration + e2e fixture): ~4 h
+* Docs + scaffold: ~1 h
+
+Total ≈ 15 h.
+
+## Decision Outcome
+
+Chosen approach: repeatable `ignore_attribute "name" { … }` blocks on `defaults {}`, per-segment globs via `gobwas/glob`, named-rule attribution surfaced in all output formats — because it extends CR-0034 without breaking it, reuses existing matcher infrastructure, and keeps preprocessing semantics (downgrade happens before classification) intact.
+
+## Implementation Status
+
+* **Started:** 2026-04-21
+* **Completed:** TBD
+* **Deployed to Production:** TBD
+* **Notes:** Branch `feat/scoped-ignore-attributes` from `main` HEAD.
+
+## Related Items
+
+* CR-0034 (`ignore_attributes`) — parent feature
+* `internal/classify/attribute_filter.go` — code being extended
+* `internal/config/config.go` — schema additions
+
+## More Information
+
+The driving real-world plan touches 21 resources under module `module.aiwz`: 19 pure tag additions (`tf-module-l2`), 2 `azurerm_monitor_diagnostic_setting` updates adding `log_analytics_destination_type = "Dedicated"`, 2 `azapi_resource` updates where the provider-computed `output` attribute flips from a populated map to `(known after apply)`, and 1 `data.azapi_resource_action` read-during-apply. With CR-0035 in place the plan becomes: 19 tag-only resources downgraded to `no-op`, 2 azapi resources downgraded to `no-op` via the `azapi_output` scoped rule, and 2 genuine diagnostic_setting updates remaining as `update` — exactly the routing the user intends.

--- a/docs/cr/CR-0035-scoped-ignore-attributes.md
+++ b/docs/cr/CR-0035-scoped-ignore-attributes.md
@@ -1,6 +1,6 @@
 ---
 id: "CR-0035"
-status: "proposed"
+status: "implemented"
 date: 2026-04-21
 requestor: Johan Karlsson
 stakeholders:
@@ -446,9 +446,9 @@ Chosen approach: repeatable `ignore_attribute "name" { … }` blocks on `default
 ## Implementation Status
 
 * **Started:** 2026-04-21
-* **Completed:** TBD
+* **Completed:** 2026-04-21
 * **Deployed to Production:** TBD
-* **Notes:** Branch `feat/scoped-ignore-attributes` from `main` HEAD.
+* **Notes:** Branch `feat/scoped-ignore-attributes` from `main` HEAD. All AC covered by unit + e2e tests. `make ci` green locally (build, test, vet, lint, govulncheck).
 
 ## Related Items
 

--- a/docs/examples/full-reference/.tfclassify.hcl
+++ b/docs/examples/full-reference/.tfclassify.hcl
@@ -333,16 +333,32 @@ defaults {
   plugin_timeout = "30s"
 
   # Attributes to ignore when determining if a resource meaningfully changed.
-  # If ALL changed attributes on an "update" resource match these prefixes,
+  # If ALL changed attributes on an "update" resource match these patterns,
   # the resource is reclassified as no-op before classification begins.
   #
-  # Uses prefix-based dot-path matching:
-  #   "tags"      → covers tags, tags.env, tags.team (but NOT tags_all)
-  #   "meta.tags" → covers meta.tags, meta.tags.env (but NOT meta.name)
+  # Uses dot-path glob matching (per-segment * and ?):
+  #   "tags"                      → covers tags, tags.env, tags.team (but NOT tags_all)
+  #   "meta.tags"                 → covers meta.tags, meta.tags.env
+  #   "tags.temp_*"               → covers tags.temp_foo, tags.temp_bar (not tags.keep)
+  #   "properties.*.createdAt"    → covers properties.rule1.createdAt (not properties.createdAt)
   #
   # Common use case: module tagging conventions where version bumps cause
   # widespread cosmetic changes (e.g., provenance tag updates).
   ignore_attributes = ["tags", "tags_all"]
+
+  # Scoped ignore rules (CR-0035). Each block is an additional ignore rule
+  # that only applies to resources whose resource/module globs match. Combine
+  # with the flat `ignore_attributes` list above for precise control — e.g.,
+  # ignore azapi's computed `output` refresh on azapi_resource only, without
+  # hiding `output` changes on any other provider.
+  #
+  # Required: label (unique), description, attributes.
+  # Optional: resource / not_resource / module / not_module (globs).
+  ignore_attribute "azapi_output" {
+    description = "azapi_resource.output is a computed read-back of the API response; not a user-authored change."
+    resource    = ["azapi_resource"]
+    attributes  = ["output"]
+  }
 }
 
 # ─── Evidence ──────────────────────────────────────────────────────────────────

--- a/internal/classify/attribute_filter.go
+++ b/internal/classify/attribute_filter.go
@@ -1,43 +1,186 @@
 package classify
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 
+	"github.com/gobwas/glob"
+	"github.com/jokarl/tfclassify/internal/config"
 	"github.com/jokarl/tfclassify/internal/plan"
 )
 
+// CompiledIgnoreRules holds pre-compiled global and scoped ignore rules for
+// a single plan-filtering pass. Build once per config load with
+// CompileIgnoreRules and reuse across every change.
+type CompiledIgnoreRules struct {
+	global []pathPattern
+	scoped []compiledIgnoreRule
+}
+
+// Empty reports whether the compiled set has any rules at all.
+func (r *CompiledIgnoreRules) Empty() bool {
+	return r == nil || (len(r.global) == 0 && len(r.scoped) == 0)
+}
+
+type compiledIgnoreRule struct {
+	name             string
+	description      string
+	resourceGlobs    []glob.Glob
+	notResourceGlobs []glob.Glob
+	moduleGlobs      []glob.Glob
+	notModuleGlobs   []glob.Glob
+	patterns         []pathPattern
+}
+
+// matches reports whether this scoped rule applies to a given resource.
+func (r *compiledIgnoreRule) matches(resourceType, moduleAddress string) bool {
+	if !matchResource(resourceType, r.resourceGlobs, r.notResourceGlobs) {
+		return false
+	}
+	if !matchModule(moduleAddress, r.moduleGlobs, r.notModuleGlobs) {
+		return false
+	}
+	return true
+}
+
+// pathPattern is a dot-segmented glob pattern. A pattern covers a concrete
+// dot-separated path if its segment count is less than or equal to the path's
+// and every pattern segment matches the corresponding path segment.
+type pathPattern struct {
+	raw      string
+	segments []glob.Glob
+}
+
+func compilePathPattern(raw string) (pathPattern, error) {
+	parts := strings.Split(raw, ".")
+	segments := make([]glob.Glob, 0, len(parts))
+	for i, seg := range parts {
+		g, err := glob.Compile(seg)
+		if err != nil {
+			return pathPattern{}, fmt.Errorf("segment %d %q: %w", i, seg, err)
+		}
+		segments = append(segments, g)
+	}
+	return pathPattern{raw: raw, segments: segments}, nil
+}
+
+func (p pathPattern) covers(path string) bool {
+	if len(p.segments) == 0 {
+		return false
+	}
+	parts := strings.Split(path, ".")
+	if len(parts) < len(p.segments) {
+		return false
+	}
+	for i, seg := range p.segments {
+		if !seg.Match(parts[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// CompileIgnoreRules compiles the defaults.ignore_attributes global list and
+// every defaults.ignore_attribute block into a reusable matcher. Returns nil
+// when the defaults block is absent or has no ignore rules.
+func CompileIgnoreRules(d *config.DefaultsConfig) (*CompiledIgnoreRules, error) {
+	if d == nil {
+		return nil, nil
+	}
+	if len(d.IgnoreAttributes) == 0 && len(d.IgnoreAttributeRules) == 0 {
+		return nil, nil
+	}
+
+	rules := &CompiledIgnoreRules{}
+
+	for _, raw := range d.IgnoreAttributes {
+		p, err := compilePathPattern(raw)
+		if err != nil {
+			return nil, fmt.Errorf("defaults.ignore_attributes %q: %w", raw, err)
+		}
+		rules.global = append(rules.global, p)
+	}
+
+	for _, r := range d.IgnoreAttributeRules {
+		compiled := compiledIgnoreRule{
+			name:        r.Name,
+			description: r.Description,
+		}
+		for _, pattern := range r.Resource {
+			g, err := glob.Compile(pattern)
+			if err != nil {
+				return nil, fmt.Errorf("defaults.ignore_attribute %q: resource %q: %w", r.Name, pattern, err)
+			}
+			compiled.resourceGlobs = append(compiled.resourceGlobs, g)
+		}
+		for _, pattern := range r.NotResource {
+			g, err := glob.Compile(pattern)
+			if err != nil {
+				return nil, fmt.Errorf("defaults.ignore_attribute %q: not_resource %q: %w", r.Name, pattern, err)
+			}
+			compiled.notResourceGlobs = append(compiled.notResourceGlobs, g)
+		}
+		for _, pattern := range r.Module {
+			g, err := glob.Compile(pattern, '.')
+			if err != nil {
+				return nil, fmt.Errorf("defaults.ignore_attribute %q: module %q: %w", r.Name, pattern, err)
+			}
+			compiled.moduleGlobs = append(compiled.moduleGlobs, g)
+		}
+		for _, pattern := range r.NotModule {
+			g, err := glob.Compile(pattern, '.')
+			if err != nil {
+				return nil, fmt.Errorf("defaults.ignore_attribute %q: not_module %q: %w", r.Name, pattern, err)
+			}
+			compiled.notModuleGlobs = append(compiled.notModuleGlobs, g)
+		}
+		for _, attr := range r.Attributes {
+			p, err := compilePathPattern(attr)
+			if err != nil {
+				return nil, fmt.Errorf("defaults.ignore_attribute %q: attribute %q: %w", r.Name, attr, err)
+			}
+			compiled.patterns = append(compiled.patterns, p)
+		}
+		rules.scoped = append(rules.scoped, compiled)
+	}
+
+	return rules, nil
+}
+
 // FilterCosmeticChanges preprocesses plan changes, downgrading cosmetic-only
 // updates to no-op. A change is cosmetic if ALL its changed attributes are
-// covered by the ignoreAttrs prefixes. Only ["update"] actions are evaluated;
-// creates, deletes, and replacements are never affected.
+// covered by the effective ignore rules for that resource — the global list
+// plus every scoped rule whose resource/module filter matches. Only
+// ["update"] actions are evaluated; creates, deletes, and replacements are
+// never affected.
 //
-// When a resource is downgraded, its OriginalActions and IgnoredAttributes
-// fields are populated for output visibility.
-func FilterCosmeticChanges(changes []plan.ResourceChange, ignoreAttrs []string) {
-	if len(ignoreAttrs) == 0 {
+// When a resource is downgraded, its OriginalActions, IgnoredAttributes, and
+// IgnoreRuleMatches fields are populated for output visibility.
+func FilterCosmeticChanges(changes []plan.ResourceChange, rules *CompiledIgnoreRules) {
+	if rules.Empty() {
 		return
 	}
 
 	for i := range changes {
 		change := &changes[i]
 
-		// Only evaluate pure update actions
 		if !isUpdateOnly(change.Actions) {
 			continue
 		}
-
-		// Updates always have both Before and After, but guard against edge cases
 		if change.Before == nil || change.After == nil {
 			continue
 		}
 
-		// Fast path: check if all changes are covered by ignore prefixes
-		if !hasOnlyIgnoredChanges(change.Before, change.After, "", ignoreAttrs) {
+		effective := effectivePatterns(rules, change.Type, change.ModuleAddress)
+		if len(effective) == 0 {
 			continue
 		}
 
-		// All changes are covered. Collect the specific paths for annotation.
+		if !hasOnlyIgnoredChanges(change.Before, change.After, "", effective) {
+			continue
+		}
+
 		changedPaths := collectChangedPaths(change.Before, change.After, "")
 		if len(changedPaths) == 0 {
 			continue
@@ -45,14 +188,65 @@ func FilterCosmeticChanges(changes []plan.ResourceChange, ignoreAttrs []string) 
 
 		change.OriginalActions = change.Actions
 		change.IgnoredAttributes = changedPaths
+		change.IgnoreRuleMatches = attributeMatches(rules, change.Type, change.ModuleAddress, changedPaths)
 		change.Actions = []string{"no-op"}
 	}
 }
 
+// effectivePatterns returns the union of the global patterns and the patterns
+// of every scoped rule whose filter matches the given resource.
+func effectivePatterns(rules *CompiledIgnoreRules, resourceType, moduleAddress string) []pathPattern {
+	if rules == nil {
+		return nil
+	}
+	effective := make([]pathPattern, 0, len(rules.global))
+	effective = append(effective, rules.global...)
+	for idx := range rules.scoped {
+		r := &rules.scoped[idx]
+		if r.matches(resourceType, moduleAddress) {
+			effective = append(effective, r.patterns...)
+		}
+	}
+	return effective
+}
+
+// attributeMatches returns the scoped rules that covered at least one of the
+// given changed paths. Global (unnamed) patterns are not reported here.
+func attributeMatches(rules *CompiledIgnoreRules, resourceType, moduleAddress string, paths []string) []plan.IgnoreRuleMatch {
+	if rules == nil || len(rules.scoped) == 0 {
+		return nil
+	}
+	var out []plan.IgnoreRuleMatch
+	for idx := range rules.scoped {
+		r := &rules.scoped[idx]
+		if !r.matches(resourceType, moduleAddress) {
+			continue
+		}
+		var covered []string
+		for _, path := range paths {
+			for _, p := range r.patterns {
+				if p.covers(path) {
+					covered = append(covered, path)
+					break
+				}
+			}
+		}
+		if len(covered) == 0 {
+			continue
+		}
+		out = append(out, plan.IgnoreRuleMatch{
+			Name:        r.name,
+			Description: r.description,
+			Paths:       covered,
+		})
+	}
+	return out
+}
+
 // hasOnlyIgnoredChanges returns true if every changed attribute between before
-// and after (at the given path prefix) is covered by the ignore prefixes.
-// It short-circuits on the first uncovered change for performance.
-func hasOnlyIgnoredChanges(before, after map[string]interface{}, pathPrefix string, ignoreAttrs []string) bool {
+// and after (at the given path prefix) is covered by at least one pattern.
+// Short-circuits on the first uncovered change.
+func hasOnlyIgnoredChanges(before, after map[string]interface{}, pathPrefix string, patterns []pathPattern) bool {
 	for _, key := range mergedKeys(before, after) {
 		path := key
 		if pathPrefix != "" {
@@ -64,26 +258,57 @@ func hasOnlyIgnoredChanges(before, after map[string]interface{}, pathPrefix stri
 			continue
 		}
 
-		// Check if this path is directly covered by a prefix
-		if isPathCovered(path, ignoreAttrs) {
+		if anyCovers(patterns, path) {
 			continue
 		}
 
-		// Not directly covered. If both values are maps and a nested ignore
-		// prefix exists under this path, recurse to check sub-attributes.
+		// Not directly covered. If both values are maps and a nested pattern
+		// extends this path, recurse to check sub-attributes.
 		bMap, bOk := bv.(map[string]interface{})
 		aMap, aOk := av.(map[string]interface{})
-		if bOk && aOk && hasNestedPrefix(path, ignoreAttrs) {
-			if !hasOnlyIgnoredChanges(bMap, aMap, path, ignoreAttrs) {
+		if bOk && aOk && hasNestedPattern(path, patterns) {
+			if !hasOnlyIgnoredChanges(bMap, aMap, path, patterns) {
 				return false
 			}
 			continue
 		}
 
-		// Uncovered change found — not cosmetic
 		return false
 	}
 	return true
+}
+
+// anyCovers returns true if any pattern covers path.
+func anyCovers(patterns []pathPattern, path string) bool {
+	for _, p := range patterns {
+		if p.covers(path) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasNestedPattern returns true if any pattern has more segments than path
+// and the pattern's leading segments match path segment-for-segment. This
+// mirrors the old "a more specific prefix lives under this path" check.
+func hasNestedPattern(path string, patterns []pathPattern) bool {
+	pathParts := strings.Split(path, ".")
+	for _, p := range patterns {
+		if len(p.segments) <= len(pathParts) {
+			continue
+		}
+		match := true
+		for i, part := range pathParts {
+			if !p.segments[i].Match(part) {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
 }
 
 // collectChangedPaths returns dot-delimited paths of all attributes that
@@ -103,7 +328,6 @@ func collectChangedPaths(before, after map[string]interface{}, pathPrefix string
 			continue
 		}
 
-		// If both are maps, recurse to find specific sub-paths
 		bMap, bOk := bv.(map[string]interface{})
 		aMap, aOk := av.(map[string]interface{})
 		if bOk && aOk {
@@ -117,40 +341,12 @@ func collectChangedPaths(before, after map[string]interface{}, pathPrefix string
 	return paths
 }
 
-// isPathCovered returns true if path equals a prefix or has a prefix as a
-// dot-delimited ancestor. For example, prefix "tags" covers "tags" and
-// "tags.env" but NOT "tags_all".
-func isPathCovered(path string, prefixes []string) bool {
-	for _, prefix := range prefixes {
-		if path == prefix {
-			return true
-		}
-		if len(path) > len(prefix) && strings.HasPrefix(path, prefix) && path[len(prefix)] == '.' {
-			return true
-		}
-	}
-	return false
-}
-
-// hasNestedPrefix returns true if any prefix starts with path + ".",
-// meaning there's a more specific ignore entry beneath this path.
-func hasNestedPrefix(path string, prefixes []string) bool {
-	needle := path + "."
-	for _, prefix := range prefixes {
-		if strings.HasPrefix(prefix, needle) {
-			return true
-		}
-	}
-	return false
-}
-
 // isUpdateOnly returns true if the actions slice is exactly ["update"].
 func isUpdateOnly(actions []string) bool {
 	return len(actions) == 1 && actions[0] == "update"
 }
 
 // mergedKeys returns the sorted union of keys from two maps.
-// Sorting ensures deterministic output order.
 func mergedKeys(m1, m2 map[string]interface{}) []string {
 	seen := make(map[string]struct{}, len(m1)+len(m2))
 	for k := range m1 {
@@ -165,4 +361,47 @@ func mergedKeys(m1, m2 map[string]interface{}) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+// matchResource mirrors classifier rule semantics: allow-list takes priority
+// over deny-list; absence of both means "match everything".
+func matchResource(resourceType string, allow, deny []glob.Glob) bool {
+	if len(allow) > 0 {
+		for _, g := range allow {
+			if g.Match(resourceType) {
+				return true
+			}
+		}
+		return false
+	}
+	if len(deny) > 0 {
+		for _, g := range deny {
+			if g.Match(resourceType) {
+				return false
+			}
+		}
+		return true
+	}
+	return true
+}
+
+// matchModule mirrors classifier rule semantics for module filters.
+func matchModule(moduleAddress string, allow, deny []glob.Glob) bool {
+	if len(allow) > 0 {
+		for _, g := range allow {
+			if g.Match(moduleAddress) {
+				return true
+			}
+		}
+		return false
+	}
+	if len(deny) > 0 {
+		for _, g := range deny {
+			if g.Match(moduleAddress) {
+				return false
+			}
+		}
+		return true
+	}
+	return true
 }

--- a/internal/classify/attribute_filter_test.go
+++ b/internal/classify/attribute_filter_test.go
@@ -1,50 +1,125 @@
 package classify
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/jokarl/tfclassify/internal/config"
 	"github.com/jokarl/tfclassify/internal/plan"
 )
 
-func TestIsPathCovered_ExactMatch(t *testing.T) {
-	if !isPathCovered("tags", []string{"tags"}) {
-		t.Error("expected 'tags' to be covered by prefix 'tags'")
+// --- helpers -----------------------------------------------------------------
+
+func compilePatterns(t *testing.T, raws ...string) []pathPattern {
+	t.Helper()
+	patterns := make([]pathPattern, 0, len(raws))
+	for _, raw := range raws {
+		p, err := compilePathPattern(raw)
+		if err != nil {
+			t.Fatalf("compilePathPattern(%q): %v", raw, err)
+		}
+		patterns = append(patterns, p)
+	}
+	return patterns
+}
+
+func isPathCovered(t *testing.T, path string, patterns ...string) bool {
+	t.Helper()
+	return anyCovers(compilePatterns(t, patterns...), path)
+}
+
+func rulesWithGlobal(t *testing.T, entries ...string) *CompiledIgnoreRules {
+	t.Helper()
+	rules, err := CompileIgnoreRules(&config.DefaultsConfig{IgnoreAttributes: entries})
+	if err != nil {
+		t.Fatalf("CompileIgnoreRules: %v", err)
+	}
+	return rules
+}
+
+// --- pathPattern (bare-prefix backward compat) -------------------------------
+
+func TestPathPattern_ExactMatch(t *testing.T) {
+	if !isPathCovered(t, "tags", "tags") {
+		t.Error("expected 'tags' to be covered by pattern 'tags'")
 	}
 }
 
-func TestIsPathCovered_PrefixMatch(t *testing.T) {
-	if !isPathCovered("tags.env", []string{"tags"}) {
-		t.Error("expected 'tags.env' to be covered by prefix 'tags'")
+func TestPathPattern_PrefixMatch(t *testing.T) {
+	if !isPathCovered(t, "tags.env", "tags") {
+		t.Error("expected 'tags.env' to be covered by pattern 'tags'")
 	}
 }
 
-func TestIsPathCovered_NoFalsePrefix(t *testing.T) {
-	if isPathCovered("tags_all", []string{"tags"}) {
-		t.Error("'tags_all' should NOT be covered by prefix 'tags'")
+func TestPathPattern_DeepPrefixMatch(t *testing.T) {
+	if !isPathCovered(t, "tags.env.team", "tags") {
+		t.Error("expected 'tags.env.team' to be covered by bare prefix 'tags'")
 	}
 }
 
-func TestIsPathCovered_NestedPrefix(t *testing.T) {
-	if !isPathCovered("meta.tags.env", []string{"meta.tags"}) {
-		t.Error("expected 'meta.tags.env' to be covered by prefix 'meta.tags'")
-	}
-	if isPathCovered("meta.name", []string{"meta.tags"}) {
-		t.Error("'meta.name' should NOT be covered by prefix 'meta.tags'")
+func TestPathPattern_NoFalsePrefix(t *testing.T) {
+	if isPathCovered(t, "tags_all", "tags") {
+		t.Error("'tags_all' must NOT be covered by pattern 'tags'")
 	}
 }
 
-func TestIsPathCovered_MultiplePrefixes(t *testing.T) {
-	prefixes := []string{"tags", "tags_all"}
-	if !isPathCovered("tags.env", prefixes) {
+func TestPathPattern_NestedPrefix(t *testing.T) {
+	if !isPathCovered(t, "meta.tags.env", "meta.tags") {
+		t.Error("expected 'meta.tags.env' to be covered by pattern 'meta.tags'")
+	}
+	if isPathCovered(t, "meta.name", "meta.tags") {
+		t.Error("'meta.name' must NOT be covered by pattern 'meta.tags'")
+	}
+}
+
+func TestPathPattern_MultiplePatterns(t *testing.T) {
+	if !isPathCovered(t, "tags.env", "tags", "tags_all") {
 		t.Error("expected 'tags.env' to be covered")
 	}
-	if !isPathCovered("tags_all.env", prefixes) {
+	if !isPathCovered(t, "tags_all.env", "tags", "tags_all") {
 		t.Error("expected 'tags_all.env' to be covered")
 	}
-	if isPathCovered("name", prefixes) {
-		t.Error("'name' should NOT be covered")
+	if isPathCovered(t, "name", "tags", "tags_all") {
+		t.Error("'name' must NOT be covered")
 	}
 }
+
+// --- pathPattern (glob semantics) --------------------------------------------
+
+func TestPathPattern_TailWildcard(t *testing.T) {
+	if !isPathCovered(t, "tags.temp_foo", "tags.temp_*") {
+		t.Error("expected 'tags.temp_foo' to be covered by 'tags.temp_*'")
+	}
+	if isPathCovered(t, "tags.keep", "tags.temp_*") {
+		t.Error("'tags.keep' must NOT be covered by 'tags.temp_*'")
+	}
+}
+
+func TestPathPattern_MidWildcard(t *testing.T) {
+	if !isPathCovered(t, "properties.rule1.tags", "properties.*.tags") {
+		t.Error("expected 'properties.rule1.tags' to be covered by 'properties.*.tags'")
+	}
+	if !isPathCovered(t, "properties.rule2.tags", "properties.*.tags") {
+		t.Error("expected 'properties.rule2.tags' to be covered by 'properties.*.tags'")
+	}
+	if isPathCovered(t, "properties.tags", "properties.*.tags") {
+		t.Error("'properties.tags' must NOT be covered by 'properties.*.tags' (segment counts differ)")
+	}
+}
+
+func TestPathPattern_LeadingWildcard(t *testing.T) {
+	if !isPathCovered(t, "meta.tags", "*.tags") {
+		t.Error("expected 'meta.tags' to be covered by '*.tags'")
+	}
+	if !isPathCovered(t, "spec.tags", "*.tags") {
+		t.Error("expected 'spec.tags' to be covered by '*.tags'")
+	}
+	if isPathCovered(t, "tags", "*.tags") {
+		t.Error("'tags' (single segment) must NOT be covered by '*.tags' (two segments)")
+	}
+}
+
+// --- collectChangedPaths ------------------------------------------------------
 
 func TestCollectChangedPaths_TopLevel(t *testing.T) {
 	before := map[string]interface{}{
@@ -124,32 +199,22 @@ func TestCollectChangedPaths_RemovedAttribute(t *testing.T) {
 	}
 }
 
-func TestHasOnlyIgnoredChanges_AllCovered(t *testing.T) {
-	before := map[string]interface{}{
-		"name": "foo",
-		"tags": map[string]interface{}{"v": "1.0"},
-	}
-	after := map[string]interface{}{
-		"name": "foo",
-		"tags": map[string]interface{}{"v": "1.1"},
-	}
+// --- hasOnlyIgnoredChanges ---------------------------------------------------
 
-	if !hasOnlyIgnoredChanges(before, after, "", []string{"tags"}) {
+func TestHasOnlyIgnoredChanges_AllCovered(t *testing.T) {
+	before := map[string]interface{}{"name": "foo", "tags": map[string]interface{}{"v": "1.0"}}
+	after := map[string]interface{}{"name": "foo", "tags": map[string]interface{}{"v": "1.1"}}
+
+	if !hasOnlyIgnoredChanges(before, after, "", compilePatterns(t, "tags")) {
 		t.Error("expected all changes to be covered by 'tags' prefix")
 	}
 }
 
 func TestHasOnlyIgnoredChanges_Uncovered(t *testing.T) {
-	before := map[string]interface{}{
-		"name": "foo",
-		"tags": map[string]interface{}{"v": "1.0"},
-	}
-	after := map[string]interface{}{
-		"name": "bar",
-		"tags": map[string]interface{}{"v": "1.1"},
-	}
+	before := map[string]interface{}{"name": "foo", "tags": map[string]interface{}{"v": "1.0"}}
+	after := map[string]interface{}{"name": "bar", "tags": map[string]interface{}{"v": "1.1"}}
 
-	if hasOnlyIgnoredChanges(before, after, "", []string{"tags"}) {
+	if hasOnlyIgnoredChanges(before, after, "", compilePatterns(t, "tags")) {
 		t.Error("expected uncovered change on 'name'")
 	}
 }
@@ -168,7 +233,7 @@ func TestHasOnlyIgnoredChanges_NestedPrefix(t *testing.T) {
 		},
 	}
 
-	if !hasOnlyIgnoredChanges(before, after, "", []string{"meta.tags"}) {
+	if !hasOnlyIgnoredChanges(before, after, "", compilePatterns(t, "meta.tags")) {
 		t.Error("expected all changes to be covered by 'meta.tags' prefix")
 	}
 }
@@ -187,10 +252,12 @@ func TestHasOnlyIgnoredChanges_NestedPrefixPartial(t *testing.T) {
 		},
 	}
 
-	if hasOnlyIgnoredChanges(before, after, "", []string{"meta.tags"}) {
+	if hasOnlyIgnoredChanges(before, after, "", compilePatterns(t, "meta.tags")) {
 		t.Error("expected uncovered change on 'meta.name'")
 	}
 }
+
+// --- FilterCosmeticChanges (global list — CR-0034 semantics) -----------------
 
 func TestFilterCosmeticChanges_TagOnly(t *testing.T) {
 	changes := []plan.ResourceChange{
@@ -203,7 +270,7 @@ func TestFilterCosmeticChanges_TagOnly(t *testing.T) {
 		},
 	}
 
-	FilterCosmeticChanges(changes, []string{"tags"})
+	FilterCosmeticChanges(changes, rulesWithGlobal(t, "tags"))
 
 	if len(changes[0].Actions) != 1 || changes[0].Actions[0] != "no-op" {
 		t.Errorf("expected actions [no-op], got %v", changes[0].Actions)
@@ -213,6 +280,9 @@ func TestFilterCosmeticChanges_TagOnly(t *testing.T) {
 	}
 	if len(changes[0].IgnoredAttributes) != 1 || changes[0].IgnoredAttributes[0] != "tags.v" {
 		t.Errorf("expected ignored_attributes [tags.v], got %v", changes[0].IgnoredAttributes)
+	}
+	if len(changes[0].IgnoreRuleMatches) != 0 {
+		t.Errorf("global list must not populate IgnoreRuleMatches, got %v", changes[0].IgnoreRuleMatches)
 	}
 }
 
@@ -227,7 +297,7 @@ func TestFilterCosmeticChanges_MixedChange(t *testing.T) {
 		},
 	}
 
-	FilterCosmeticChanges(changes, []string{"tags"})
+	FilterCosmeticChanges(changes, rulesWithGlobal(t, "tags"))
 
 	if changes[0].Actions[0] != "update" {
 		t.Errorf("expected actions unchanged [update], got %v", changes[0].Actions)
@@ -247,7 +317,7 @@ func TestFilterCosmeticChanges_CreateNotAffected(t *testing.T) {
 		},
 	}
 
-	FilterCosmeticChanges(changes, []string{"tags"})
+	FilterCosmeticChanges(changes, rulesWithGlobal(t, "tags"))
 
 	if changes[0].Actions[0] != "create" {
 		t.Errorf("expected create unchanged, got %v", changes[0].Actions)
@@ -264,7 +334,7 @@ func TestFilterCosmeticChanges_DeleteNotAffected(t *testing.T) {
 		},
 	}
 
-	FilterCosmeticChanges(changes, []string{"tags"})
+	FilterCosmeticChanges(changes, rulesWithGlobal(t, "tags"))
 
 	if changes[0].Actions[0] != "delete" {
 		t.Errorf("expected delete unchanged, got %v", changes[0].Actions)
@@ -282,7 +352,7 @@ func TestFilterCosmeticChanges_ReplaceNotAffected(t *testing.T) {
 		},
 	}
 
-	FilterCosmeticChanges(changes, []string{"tags"})
+	FilterCosmeticChanges(changes, rulesWithGlobal(t, "tags"))
 
 	if len(changes[0].Actions) != 2 {
 		t.Errorf("expected replace unchanged, got %v", changes[0].Actions)
@@ -326,7 +396,7 @@ func TestFilterCosmeticChanges_MultiplePrefixes(t *testing.T) {
 		},
 	}
 
-	FilterCosmeticChanges(changes, []string{"tags", "tags_all"})
+	FilterCosmeticChanges(changes, rulesWithGlobal(t, "tags", "tags_all"))
 
 	if changes[0].Actions[0] != "no-op" {
 		t.Errorf("expected [no-op] with multiple prefixes, got %v", changes[0].Actions)
@@ -358,7 +428,7 @@ func TestFilterCosmeticChanges_MultipleResources(t *testing.T) {
 		},
 	}
 
-	FilterCosmeticChanges(changes, []string{"tags"})
+	FilterCosmeticChanges(changes, rulesWithGlobal(t, "tags"))
 
 	if changes[0].Actions[0] != "no-op" {
 		t.Errorf("res.cosmetic: expected [no-op], got %v", changes[0].Actions)
@@ -369,7 +439,6 @@ func TestFilterCosmeticChanges_MultipleResources(t *testing.T) {
 	if changes[2].Actions[0] != "no-op" {
 		t.Errorf("res.noop: expected [no-op], got %v", changes[2].Actions)
 	}
-	// Only the cosmetic resource should have annotations
 	if changes[0].OriginalActions == nil {
 		t.Error("res.cosmetic: expected original_actions to be set")
 	}
@@ -392,8 +461,7 @@ func TestFilterCosmeticChanges_NilBeforeAfter(t *testing.T) {
 		},
 	}
 
-	// Should not panic
-	FilterCosmeticChanges(changes, []string{"tags"})
+	FilterCosmeticChanges(changes, rulesWithGlobal(t, "tags"))
 
 	if changes[0].Actions[0] != "update" {
 		t.Errorf("expected update unchanged when before/after nil, got %v", changes[0].Actions)
@@ -411,9 +479,265 @@ func TestFilterCosmeticChanges_NoOpNotReprocessed(t *testing.T) {
 		},
 	}
 
-	FilterCosmeticChanges(changes, []string{"tags"})
+	FilterCosmeticChanges(changes, rulesWithGlobal(t, "tags"))
 
 	if changes[0].OriginalActions != nil {
 		t.Error("no-op resources should not get original_actions annotation")
+	}
+}
+
+// --- FilterCosmeticChanges (scoped blocks — CR-0035) -------------------------
+
+func TestFilter_ScopedRule_MatchesAzapiOnly(t *testing.T) {
+	defaults := &config.DefaultsConfig{
+		IgnoreAttributes: []string{"tags"},
+		IgnoreAttributeRules: []config.IgnoreAttributeRule{{
+			Name:        "azapi_output",
+			Description: "azapi computed refresh",
+			Resource:    []string{"azapi_resource"},
+			Attributes:  []string{"output"},
+		}},
+	}
+	rules, err := CompileIgnoreRules(defaults)
+	if err != nil {
+		t.Fatalf("CompileIgnoreRules: %v", err)
+	}
+
+	changes := []plan.ResourceChange{
+		{
+			Address: "azapi_resource.this",
+			Type:    "azapi_resource",
+			Actions: []string{"update"},
+			Before: map[string]interface{}{
+				"tags":   map[string]interface{}{"v": "1.0"},
+				"output": map[string]interface{}{"id": "before"},
+			},
+			After: map[string]interface{}{
+				"tags":   map[string]interface{}{"v": "1.1"},
+				"output": map[string]interface{}{"id": "after"},
+			},
+		},
+		{
+			Address: "azurerm_storage_account.this",
+			Type:    "azurerm_storage_account",
+			Actions: []string{"update"},
+			Before: map[string]interface{}{
+				"tags":   map[string]interface{}{"v": "1.0"},
+				"output": map[string]interface{}{"id": "before"},
+			},
+			After: map[string]interface{}{
+				"tags":   map[string]interface{}{"v": "1.1"},
+				"output": map[string]interface{}{"id": "after"},
+			},
+		},
+	}
+
+	FilterCosmeticChanges(changes, rules)
+
+	if changes[0].Actions[0] != "no-op" {
+		t.Errorf("azapi: expected no-op, got %v", changes[0].Actions)
+	}
+	if len(changes[0].IgnoreRuleMatches) != 1 || changes[0].IgnoreRuleMatches[0].Name != "azapi_output" {
+		t.Errorf("azapi: expected IgnoreRuleMatches=[azapi_output], got %v", changes[0].IgnoreRuleMatches)
+	}
+	if changes[0].IgnoreRuleMatches[0].Description != "azapi computed refresh" {
+		t.Errorf("azapi: expected description propagated, got %q", changes[0].IgnoreRuleMatches[0].Description)
+	}
+
+	if changes[1].Actions[0] != "update" {
+		t.Errorf("storage: expected update (scoped rule must not apply), got %v", changes[1].Actions)
+	}
+	if len(changes[1].IgnoreRuleMatches) != 0 {
+		t.Errorf("storage: expected no IgnoreRuleMatches, got %v", changes[1].IgnoreRuleMatches)
+	}
+}
+
+func TestFilter_ScopedRule_UnionWithGlobal(t *testing.T) {
+	defaults := &config.DefaultsConfig{
+		IgnoreAttributes: []string{"tags"},
+		IgnoreAttributeRules: []config.IgnoreAttributeRule{{
+			Name:        "azapi_output",
+			Description: "azapi computed refresh",
+			Resource:    []string{"azapi_*"},
+			Attributes:  []string{"output"},
+		}},
+	}
+	rules, err := CompileIgnoreRules(defaults)
+	if err != nil {
+		t.Fatalf("CompileIgnoreRules: %v", err)
+	}
+
+	changes := []plan.ResourceChange{{
+		Address: "azapi_resource.vnet",
+		Type:    "azapi_resource",
+		Actions: []string{"update"},
+		Before: map[string]interface{}{
+			"tags":   map[string]interface{}{"env": "prod"},
+			"output": map[string]interface{}{"id": "x"},
+		},
+		After: map[string]interface{}{
+			"tags":   map[string]interface{}{"env": "staging"},
+			"output": map[string]interface{}{"id": "y"},
+		},
+	}}
+
+	FilterCosmeticChanges(changes, rules)
+
+	if changes[0].Actions[0] != "no-op" {
+		t.Fatalf("expected no-op, got %v", changes[0].Actions)
+	}
+	if len(changes[0].IgnoredAttributes) != 2 {
+		t.Errorf("expected 2 ignored paths, got %v", changes[0].IgnoredAttributes)
+	}
+	if len(changes[0].IgnoreRuleMatches) != 1 {
+		t.Fatalf("expected 1 scoped rule attributed, got %v", changes[0].IgnoreRuleMatches)
+	}
+	match := changes[0].IgnoreRuleMatches[0]
+	if match.Name != "azapi_output" {
+		t.Errorf("expected rule name azapi_output, got %q", match.Name)
+	}
+	if len(match.Paths) != 1 || match.Paths[0] != "output.id" {
+		t.Errorf("expected attributed path [output.id], got %v", match.Paths)
+	}
+}
+
+func TestFilter_ScopedRule_DoesNotApplyIfResourceUnmatched(t *testing.T) {
+	defaults := &config.DefaultsConfig{
+		IgnoreAttributeRules: []config.IgnoreAttributeRule{{
+			Name:        "azapi_only",
+			Description: "only azapi",
+			Resource:    []string{"azapi_resource"},
+			Attributes:  []string{"output"},
+		}},
+	}
+	rules, err := CompileIgnoreRules(defaults)
+	if err != nil {
+		t.Fatalf("CompileIgnoreRules: %v", err)
+	}
+
+	changes := []plan.ResourceChange{{
+		Address: "azurerm_key_vault.this",
+		Type:    "azurerm_key_vault",
+		Actions: []string{"update"},
+		Before:  map[string]interface{}{"output": map[string]interface{}{"id": "x"}},
+		After:   map[string]interface{}{"output": map[string]interface{}{"id": "y"}},
+	}}
+
+	FilterCosmeticChanges(changes, rules)
+
+	if changes[0].Actions[0] != "update" {
+		t.Errorf("expected update on unmatched resource, got %v", changes[0].Actions)
+	}
+	if len(changes[0].IgnoreRuleMatches) != 0 {
+		t.Errorf("expected no rule matches, got %v", changes[0].IgnoreRuleMatches)
+	}
+}
+
+func TestFilter_ScopedRule_ModuleFilter(t *testing.T) {
+	defaults := &config.DefaultsConfig{
+		IgnoreAttributeRules: []config.IgnoreAttributeRule{{
+			Name:        "platform_only",
+			Description: "only for platform module tree",
+			Module:      []string{"module.platform.**"},
+			Attributes:  []string{"tags"},
+		}},
+	}
+	rules, err := CompileIgnoreRules(defaults)
+	if err != nil {
+		t.Fatalf("CompileIgnoreRules: %v", err)
+	}
+
+	changes := []plan.ResourceChange{
+		{
+			Address:       "module.platform.app.azurerm_rg.r",
+			Type:          "azurerm_resource_group",
+			Actions:       []string{"update"},
+			ModuleAddress: "module.platform.app",
+			Before:        map[string]interface{}{"tags": map[string]interface{}{"v": "1.0"}},
+			After:         map[string]interface{}{"tags": map[string]interface{}{"v": "1.1"}},
+		},
+		{
+			Address:       "module.other.azurerm_rg.r",
+			Type:          "azurerm_resource_group",
+			Actions:       []string{"update"},
+			ModuleAddress: "module.other",
+			Before:        map[string]interface{}{"tags": map[string]interface{}{"v": "1.0"}},
+			After:         map[string]interface{}{"tags": map[string]interface{}{"v": "1.1"}},
+		},
+	}
+
+	FilterCosmeticChanges(changes, rules)
+
+	if changes[0].Actions[0] != "no-op" {
+		t.Errorf("platform: expected no-op, got %v", changes[0].Actions)
+	}
+	if changes[1].Actions[0] != "update" {
+		t.Errorf("other module: expected update, got %v", changes[1].Actions)
+	}
+}
+
+func TestFilter_PathGlob_MidWildcard(t *testing.T) {
+	defaults := &config.DefaultsConfig{
+		IgnoreAttributeRules: []config.IgnoreAttributeRule{{
+			Name:        "timestamps",
+			Description: "transient timestamps",
+			Resource:    []string{"*"},
+			Attributes:  []string{"properties.*.createdAt"},
+		}},
+	}
+	rules, err := CompileIgnoreRules(defaults)
+	if err != nil {
+		t.Fatalf("CompileIgnoreRules: %v", err)
+	}
+
+	changes := []plan.ResourceChange{{
+		Address: "r.this",
+		Type:    "r",
+		Actions: []string{"update"},
+		Before: map[string]interface{}{
+			"properties": map[string]interface{}{
+				"rule1": map[string]interface{}{"createdAt": "t0"},
+				"rule2": map[string]interface{}{"createdAt": "t0"},
+			},
+		},
+		After: map[string]interface{}{
+			"properties": map[string]interface{}{
+				"rule1": map[string]interface{}{"createdAt": "t1"},
+				"rule2": map[string]interface{}{"createdAt": "t1"},
+			},
+		},
+	}}
+
+	FilterCosmeticChanges(changes, rules)
+
+	if changes[0].Actions[0] != "no-op" {
+		t.Errorf("expected no-op, got %v", changes[0].Actions)
+	}
+}
+
+// --- CompileIgnoreRules (validation) -----------------------------------------
+
+func TestCompileIgnoreRules_NilOrEmpty(t *testing.T) {
+	if r, err := CompileIgnoreRules(nil); err != nil || r != nil {
+		t.Errorf("expected (nil, nil) for nil defaults, got (%v, %v)", r, err)
+	}
+	if r, err := CompileIgnoreRules(&config.DefaultsConfig{}); err != nil || r != nil {
+		t.Errorf("expected (nil, nil) for empty defaults, got (%v, %v)", r, err)
+	}
+}
+
+func TestCompileIgnoreRules_InvalidGlob(t *testing.T) {
+	_, err := CompileIgnoreRules(&config.DefaultsConfig{
+		IgnoreAttributeRules: []config.IgnoreAttributeRule{{
+			Name:        "bad",
+			Description: "bad glob",
+			Attributes:  []string{"["},
+		}},
+	})
+	if err == nil {
+		t.Fatal("expected compile error for invalid glob, got nil")
+	}
+	if !strings.Contains(err.Error(), "bad") {
+		t.Errorf("expected error to mention rule name, got %v", err)
 	}
 }

--- a/internal/classify/classifier.go
+++ b/internal/classify/classifier.go
@@ -94,6 +94,7 @@ func (c *Classifier) classifyResource(change plan.ResourceChange) ResourceDecisi
 		Actions:           change.Actions,
 		OriginalActions:   change.OriginalActions,
 		IgnoredAttributes: change.IgnoredAttributes,
+		IgnoreRuleMatches: change.IgnoreRuleMatches,
 	}
 
 	// Try each classification in precedence order
@@ -171,6 +172,7 @@ func (c *Classifier) explainResource(change plan.ResourceChange) ResourceExplana
 		Actions:           change.Actions,
 		OriginalActions:   change.OriginalActions,
 		IgnoredAttributes: change.IgnoredAttributes,
+		IgnoreRuleMatches: change.IgnoreRuleMatches,
 	}
 
 	// Track the best match (same logic as classifyResource, but evaluate all)

--- a/internal/classify/result.go
+++ b/internal/classify/result.go
@@ -1,7 +1,11 @@
 // Package classify provides the core classification engine.
 package classify
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/jokarl/tfclassify/internal/plan"
+)
 
 // Result contains the classification results for a plan.
 type Result struct {
@@ -23,6 +27,7 @@ type ResourceDecision struct {
 	Metadata                  map[string]interface{} // plugin-provided metadata (optional)
 	OriginalActions           []string               // set when actions were rewritten by ignore_attributes
 	IgnoredAttributes         []string               // attribute paths covered by ignore_attributes
+	IgnoreRuleMatches         []plan.IgnoreRuleMatch // scoped ignore_attribute rules (CR-0035) that contributed
 }
 
 // ExplainResult contains full trace data for explain output.
@@ -40,8 +45,9 @@ type ResourceExplanation struct {
 	FinalSource         string // "core-rule", "builtin: <name>", "plugin: <plugin>/<analyzer>"
 	WinnerReason        string
 	Trace               []TraceEntry
-	OriginalActions     []string // set when actions were rewritten by ignore_attributes
-	IgnoredAttributes   []string // attribute paths covered by ignore_attributes
+	OriginalActions     []string               // set when actions were rewritten by ignore_attributes
+	IgnoredAttributes   []string               // attribute paths covered by ignore_attributes
+	IgnoreRuleMatches   []plan.IgnoreRuleMatch // scoped ignore_attribute rules (CR-0035) that contributed
 }
 
 // TraceResult represents the evaluation outcome.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -169,9 +169,24 @@ type RuleConfig struct {
 
 // DefaultsConfig contains default configuration values.
 type DefaultsConfig struct {
-	Unclassified        string   `hcl:"unclassified"`
-	NoChanges           string   `hcl:"no_changes"`
-	PluginTimeout       string   `hcl:"plugin_timeout,optional"`
-	DriftClassification string   `hcl:"drift_classification,optional"`
-	IgnoreAttributes    []string `hcl:"ignore_attributes,optional"`
+	Unclassified         string                `hcl:"unclassified"`
+	NoChanges            string                `hcl:"no_changes"`
+	PluginTimeout        string                `hcl:"plugin_timeout,optional"`
+	DriftClassification  string                `hcl:"drift_classification,optional"`
+	IgnoreAttributes     []string              `hcl:"ignore_attributes,optional"`
+	IgnoreAttributeRules []IgnoreAttributeRule `hcl:"ignore_attribute,block"`
+}
+
+// IgnoreAttributeRule is a scoped ignore rule that applies only to resources
+// matching its resource/module filters. Attributes support per-segment globs
+// (e.g. "properties.*.createdAt"). Introduced by CR-0035; see CR-0034 for the
+// unscoped global list that this extends.
+type IgnoreAttributeRule struct {
+	Name        string   `hcl:"name,label"`
+	Description string   `hcl:"description"`
+	Resource    []string `hcl:"resource,optional"`
+	NotResource []string `hcl:"not_resource,optional"`
+	Module      []string `hcl:"module,optional"`
+	NotModule   []string `hcl:"not_module,optional"`
+	Attributes  []string `hcl:"attributes"`
 }

--- a/internal/config/testdata/ignore_attribute_duplicate_name.hcl
+++ b/internal/config/testdata/ignore_attribute_duplicate_name.hcl
@@ -1,0 +1,21 @@
+classification "standard" {
+  description = "Standard"
+  rule { resource = ["*"] }
+}
+
+precedence = ["standard"]
+
+defaults {
+  unclassified = "standard"
+  no_changes   = "standard"
+
+  ignore_attribute "dup" {
+    description = "first"
+    attributes  = ["a"]
+  }
+
+  ignore_attribute "dup" {
+    description = "second"
+    attributes  = ["b"]
+  }
+}

--- a/internal/config/testdata/ignore_attribute_empty_attributes.hcl
+++ b/internal/config/testdata/ignore_attribute_empty_attributes.hcl
@@ -1,0 +1,16 @@
+classification "standard" {
+  description = "Standard"
+  rule { resource = ["*"] }
+}
+
+precedence = ["standard"]
+
+defaults {
+  unclassified = "standard"
+  no_changes   = "standard"
+
+  ignore_attribute "bad" {
+    description = "missing attributes"
+    attributes  = []
+  }
+}

--- a/internal/config/testdata/ignore_attribute_invalid_glob.hcl
+++ b/internal/config/testdata/ignore_attribute_invalid_glob.hcl
@@ -1,0 +1,16 @@
+classification "standard" {
+  description = "Standard"
+  rule { resource = ["*"] }
+}
+
+precedence = ["standard"]
+
+defaults {
+  unclassified = "standard"
+  no_changes   = "standard"
+
+  ignore_attribute "bad" {
+    description = "unparseable glob"
+    attributes  = ["["]
+  }
+}

--- a/internal/config/testdata/ignore_attribute_missing_description.hcl
+++ b/internal/config/testdata/ignore_attribute_missing_description.hcl
@@ -1,0 +1,16 @@
+classification "standard" {
+  description = "Standard"
+  rule { resource = ["*"] }
+}
+
+precedence = ["standard"]
+
+defaults {
+  unclassified = "standard"
+  no_changes   = "standard"
+
+  ignore_attribute "bad" {
+    description = ""
+    attributes  = ["output"]
+  }
+}

--- a/internal/config/testdata/ignore_attribute_scoped_valid.hcl
+++ b/internal/config/testdata/ignore_attribute_scoped_valid.hcl
@@ -1,0 +1,27 @@
+classification "standard" {
+  description = "Standard change"
+
+  rule {
+    resource = ["*"]
+  }
+}
+
+precedence = ["standard"]
+
+defaults {
+  unclassified      = "standard"
+  no_changes        = "standard"
+  ignore_attributes = ["tags"]
+
+  ignore_attribute "azapi_output" {
+    description = "azapi computed refresh"
+    resource    = ["azapi_resource"]
+    attributes  = ["output"]
+  }
+
+  ignore_attribute "timestamps" {
+    description = "transient timestamps"
+    resource    = ["azapi_*"]
+    attributes  = ["properties.*.createdAt", "properties.*.updatedAt"]
+  }
+}

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -236,7 +236,10 @@ func validateSARIFLevels(cfg *Config) error {
 	return nil
 }
 
-// validateIgnoreAttributes checks that ignore_attributes entries are non-empty strings.
+// validateIgnoreAttributes checks that ignore_attributes entries are non-empty
+// strings and that scoped ignore_attribute blocks are well-formed (required
+// description, non-empty attributes, unique names, compilable globs on resource,
+// module, and attribute fields).
 func validateIgnoreAttributes(cfg *Config) error {
 	if cfg.Defaults == nil {
 		return nil
@@ -244,6 +247,59 @@ func validateIgnoreAttributes(cfg *Config) error {
 	for i, attr := range cfg.Defaults.IgnoreAttributes {
 		if strings.TrimSpace(attr) == "" {
 			return fmt.Errorf("defaults.ignore_attributes[%d]: entry must not be empty", i)
+		}
+	}
+
+	seen := make(map[string]struct{}, len(cfg.Defaults.IgnoreAttributeRules))
+	for i, rule := range cfg.Defaults.IgnoreAttributeRules {
+		if rule.Name == "" {
+			return fmt.Errorf("defaults.ignore_attribute[%d]: label is required", i)
+		}
+		if _, dup := seen[rule.Name]; dup {
+			return fmt.Errorf("defaults.ignore_attribute[%d]: duplicate name %q", i, rule.Name)
+		}
+		seen[rule.Name] = struct{}{}
+
+		if strings.TrimSpace(rule.Description) == "" {
+			return fmt.Errorf("defaults.ignore_attribute %q: description must not be empty", rule.Name)
+		}
+		if len(rule.Attributes) == 0 {
+			return fmt.Errorf("defaults.ignore_attribute %q: attributes must not be empty", rule.Name)
+		}
+		for j, attr := range rule.Attributes {
+			if strings.TrimSpace(attr) == "" {
+				return fmt.Errorf("defaults.ignore_attribute %q: attributes[%d] must not be empty", rule.Name, j)
+			}
+			for seg, segment := range strings.Split(attr, ".") {
+				if _, err := glob.Compile(segment); err != nil {
+					return fmt.Errorf("defaults.ignore_attribute %q: attributes[%d] segment %d %q: invalid glob: %w",
+						rule.Name, j, seg, segment, err)
+				}
+			}
+		}
+		for j, pattern := range rule.Resource {
+			if _, err := glob.Compile(pattern); err != nil {
+				return fmt.Errorf("defaults.ignore_attribute %q: invalid resource pattern %q at index %d: %w",
+					rule.Name, pattern, j, err)
+			}
+		}
+		for j, pattern := range rule.NotResource {
+			if _, err := glob.Compile(pattern); err != nil {
+				return fmt.Errorf("defaults.ignore_attribute %q: invalid not_resource pattern %q at index %d: %w",
+					rule.Name, pattern, j, err)
+			}
+		}
+		for j, pattern := range rule.Module {
+			if _, err := glob.Compile(pattern, '.'); err != nil {
+				return fmt.Errorf("defaults.ignore_attribute %q: invalid module pattern %q at index %d: %w",
+					rule.Name, pattern, j, err)
+			}
+		}
+		for j, pattern := range rule.NotModule {
+			if _, err := glob.Compile(pattern, '.'); err != nil {
+				return fmt.Errorf("defaults.ignore_attribute %q: invalid not_module pattern %q at index %d: %w",
+					rule.Name, pattern, j, err)
+			}
 		}
 	}
 	return nil

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -661,6 +661,62 @@ func TestValidate_IgnoreAttributesValid(t *testing.T) {
 	}
 }
 
+func TestValidate_IgnoreAttributeScopedValid(t *testing.T) {
+	cfg, err := LoadFile("testdata/ignore_attribute_scoped_valid.hcl")
+	if err != nil {
+		t.Fatalf("expected no error for valid scoped ignore_attribute blocks, got: %v", err)
+	}
+	if len(cfg.Defaults.IgnoreAttributeRules) != 2 {
+		t.Fatalf("expected 2 scoped rules, got %d", len(cfg.Defaults.IgnoreAttributeRules))
+	}
+	if cfg.Defaults.IgnoreAttributeRules[0].Name != "azapi_output" {
+		t.Errorf("first rule name: got %q", cfg.Defaults.IgnoreAttributeRules[0].Name)
+	}
+	if cfg.Defaults.IgnoreAttributeRules[1].Attributes[0] != "properties.*.createdAt" {
+		t.Errorf("second rule first attribute: got %q", cfg.Defaults.IgnoreAttributeRules[1].Attributes[0])
+	}
+}
+
+func TestValidate_IgnoreAttributeMissingDescription(t *testing.T) {
+	_, err := LoadFile("testdata/ignore_attribute_missing_description.hcl")
+	if err == nil {
+		t.Fatal("expected error for missing description, got nil")
+	}
+	if !strings.Contains(err.Error(), "description") {
+		t.Errorf("expected error to mention description, got: %v", err)
+	}
+}
+
+func TestValidate_IgnoreAttributeDuplicateName(t *testing.T) {
+	_, err := LoadFile("testdata/ignore_attribute_duplicate_name.hcl")
+	if err == nil {
+		t.Fatal("expected error for duplicate block name, got nil")
+	}
+	if !strings.Contains(err.Error(), "duplicate") {
+		t.Errorf("expected error to mention duplicate, got: %v", err)
+	}
+}
+
+func TestValidate_IgnoreAttributeEmptyAttributes(t *testing.T) {
+	_, err := LoadFile("testdata/ignore_attribute_empty_attributes.hcl")
+	if err == nil {
+		t.Fatal("expected error for empty attributes list, got nil")
+	}
+	if !strings.Contains(err.Error(), "attributes") {
+		t.Errorf("expected error to mention attributes, got: %v", err)
+	}
+}
+
+func TestValidate_IgnoreAttributeInvalidGlob(t *testing.T) {
+	_, err := LoadFile("testdata/ignore_attribute_invalid_glob.hcl")
+	if err == nil {
+		t.Fatal("expected error for invalid glob, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid glob") {
+		t.Errorf("expected error to mention invalid glob, got: %v", err)
+	}
+}
+
 func TestValidateWarnings_EmptyClassification_WithPlugin(t *testing.T) {
 	cfg := &Config{
 		Classifications: []ClassificationConfig{

--- a/internal/output/evidence.go
+++ b/internal/output/evidence.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/jokarl/tfclassify/internal/classify"
 	"github.com/jokarl/tfclassify/internal/config"
+	"github.com/jokarl/tfclassify/internal/plan"
 )
 
 // EvidenceArtifact is the JSON structure written as the evidence file.
@@ -34,14 +35,15 @@ type EvidenceArtifact struct {
 
 // EvidenceResource represents a single resource in the evidence artifact.
 type EvidenceResource struct {
-	Address                   string   `json:"address"`
-	Type                      string   `json:"type"`
-	Actions                   []string `json:"actions"`
-	Classification            string   `json:"classification"`
-	ClassificationDescription string   `json:"classification_description,omitempty"`
-	MatchedRules              []string `json:"matched_rules"`
-	OriginalActions           []string `json:"original_actions,omitempty"`
-	IgnoredAttributes         []string `json:"ignored_attributes,omitempty"`
+	Address                   string                 `json:"address"`
+	Type                      string                 `json:"type"`
+	Actions                   []string               `json:"actions"`
+	Classification            string                 `json:"classification"`
+	ClassificationDescription string                 `json:"classification_description,omitempty"`
+	MatchedRules              []string               `json:"matched_rules"`
+	OriginalActions           []string               `json:"original_actions,omitempty"`
+	IgnoredAttributes         []string               `json:"ignored_attributes,omitempty"`
+	IgnoreRuleMatches         []plan.IgnoreRuleMatch `json:"ignore_rule_matches,omitempty"`
 }
 
 // EvidenceTrace represents a single trace entry in the evidence artifact.
@@ -101,6 +103,7 @@ func BuildEvidence(result *classify.Result, explainResult *classify.ExplainResul
 				MatchedRules:              d.MatchedRules,
 				OriginalActions:           d.OriginalActions,
 				IgnoredAttributes:         d.IgnoredAttributes,
+				IgnoreRuleMatches:         d.IgnoreRuleMatches,
 			})
 		}
 		artifact.Resources = resources

--- a/internal/output/explain.go
+++ b/internal/output/explain.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/jokarl/tfclassify/internal/classify"
+	"github.com/jokarl/tfclassify/internal/plan"
 )
 
 // FormatExplain outputs the explain result in the configured format.
@@ -41,6 +42,9 @@ func (f *Formatter) formatExplainText(result *classify.ExplainResult) error {
 		if len(res.OriginalActions) > 0 {
 			fmt.Fprintf(&sb, "          Originally %v, downgraded by ignore_attributes: %s\n",
 				res.OriginalActions, strings.Join(res.IgnoredAttributes, ", "))
+			for _, m := range res.IgnoreRuleMatches {
+				fmt.Fprintf(&sb, "          Matched rule %q: %s\n", m.Name, m.Description)
+			}
 		}
 		fmt.Fprintf(&sb, "Final:    %s (from %s)\n", res.FinalClassification, res.FinalSource)
 		sb.WriteString("\n  Evaluation trace:\n")
@@ -81,15 +85,16 @@ type ExplainJSONOutput struct {
 
 // ExplainJSONResource represents a single resource in explain JSON output.
 type ExplainJSONResource struct {
-	Address             string             `json:"address"`
-	Type                string             `json:"type"`
-	Actions             []string           `json:"actions"`
-	FinalClassification string             `json:"final_classification"`
-	FinalSource         string             `json:"final_source"`
-	Trace               []ExplainJSONTrace `json:"trace"`
-	WinnerReason        string             `json:"winner_reason"`
-	OriginalActions     []string           `json:"original_actions,omitempty"`
-	IgnoredAttributes   []string           `json:"ignored_attributes,omitempty"`
+	Address             string                 `json:"address"`
+	Type                string                 `json:"type"`
+	Actions             []string               `json:"actions"`
+	FinalClassification string                 `json:"final_classification"`
+	FinalSource         string                 `json:"final_source"`
+	Trace               []ExplainJSONTrace     `json:"trace"`
+	WinnerReason        string                 `json:"winner_reason"`
+	OriginalActions     []string               `json:"original_actions,omitempty"`
+	IgnoredAttributes   []string               `json:"ignored_attributes,omitempty"`
+	IgnoreRuleMatches   []plan.IgnoreRuleMatch `json:"ignore_rule_matches,omitempty"`
 }
 
 // ExplainJSONTrace represents a single trace entry in explain JSON output.
@@ -118,6 +123,7 @@ func (f *Formatter) formatExplainJSON(result *classify.ExplainResult) error {
 			Trace:               make([]ExplainJSONTrace, 0, len(res.Trace)),
 			OriginalActions:     res.OriginalActions,
 			IgnoredAttributes:   res.IgnoredAttributes,
+			IgnoreRuleMatches:   res.IgnoreRuleMatches,
 		}
 
 		for _, entry := range res.Trace {

--- a/internal/output/formatter.go
+++ b/internal/output/formatter.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/jokarl/tfclassify/internal/classify"
+	"github.com/jokarl/tfclassify/internal/plan"
 )
 
 // Format represents the output format type.
@@ -82,14 +83,15 @@ type JSONOutput struct {
 
 // JSONResource represents a single resource in JSON output.
 type JSONResource struct {
-	Address                   string   `json:"address"`
-	Type                      string   `json:"type"`
-	Actions                   []string `json:"actions"`
-	Classification            string   `json:"classification"`
-	ClassificationDescription string   `json:"classification_description,omitempty"`
-	MatchedRules              []string `json:"matched_rules"`
-	OriginalActions           []string `json:"original_actions,omitempty"`
-	IgnoredAttributes         []string `json:"ignored_attributes,omitempty"`
+	Address                   string                 `json:"address"`
+	Type                      string                 `json:"type"`
+	Actions                   []string               `json:"actions"`
+	Classification            string                 `json:"classification"`
+	ClassificationDescription string                 `json:"classification_description,omitempty"`
+	MatchedRules              []string               `json:"matched_rules"`
+	OriginalActions           []string               `json:"original_actions,omitempty"`
+	IgnoredAttributes         []string               `json:"ignored_attributes,omitempty"`
+	IgnoreRuleMatches         []plan.IgnoreRuleMatch `json:"ignore_rule_matches,omitempty"`
 }
 
 func (f *Formatter) formatJSON(result *classify.Result) error {
@@ -111,6 +113,7 @@ func (f *Formatter) formatJSON(result *classify.Result) error {
 			MatchedRules:              decision.MatchedRules,
 			OriginalActions:           decision.OriginalActions,
 			IgnoredAttributes:         decision.IgnoredAttributes,
+			IgnoreRuleMatches:         decision.IgnoreRuleMatches,
 		})
 	}
 
@@ -146,6 +149,9 @@ func (f *Formatter) formatText(result *classify.Result) error {
 					fmt.Fprintf(&sb, "  - %s (%s)\n", d.Address, d.ResourceType)
 					fmt.Fprintf(&sb, "    Originally: %v (downgraded by ignore_attributes: %s)\n",
 						d.OriginalActions, strings.Join(d.IgnoredAttributes, ", "))
+					for _, m := range d.IgnoreRuleMatches {
+						fmt.Fprintf(&sb, "    Matched rule %q: %s\n", m.Name, m.Description)
+					}
 				}
 			}
 		}
@@ -202,6 +208,9 @@ func (f *Formatter) formatText(result *classify.Result) error {
 					if len(decision.OriginalActions) > 0 {
 						fmt.Fprintf(&sb, "    Originally: %v (downgraded by ignore_attributes: %s)\n",
 							decision.OriginalActions, strings.Join(decision.IgnoredAttributes, ", "))
+						for _, m := range decision.IgnoreRuleMatches {
+							fmt.Fprintf(&sb, "    Matched rule %q: %s\n", m.Name, m.Description)
+						}
 					}
 					for _, rule := range decision.MatchedRules {
 						fmt.Fprintf(&sb, "    Rule: %s\n", rule)

--- a/internal/output/sarif.go
+++ b/internal/output/sarif.go
@@ -102,6 +102,9 @@ func (f *Formatter) formatSARIF(result *classify.Result) error {
 		if len(d.OriginalActions) > 0 {
 			msgText += fmt.Sprintf(" (originally %v, downgraded by ignore_attributes: %s)",
 				d.OriginalActions, strings.Join(d.IgnoredAttributes, ", "))
+			for _, m := range d.IgnoreRuleMatches {
+				msgText += fmt.Sprintf(" [rule %q: %s]", m.Name, m.Description)
+			}
 		}
 
 		results = append(results, sarifResult{

--- a/internal/plan/types.go
+++ b/internal/plan/types.go
@@ -22,6 +22,18 @@ type ResourceChange struct {
 	// IgnoredAttributes lists the specific attribute paths that were filtered
 	// by ignore_attributes (e.g., ["tags.tf-module-l2"]).
 	IgnoredAttributes []string
+	// IgnoreRuleMatches records scoped ignore_attribute blocks (CR-0035) that
+	// covered at least one changed path on this resource. The global
+	// ignore_attributes list does not appear here — only named scoped rules do.
+	IgnoreRuleMatches []IgnoreRuleMatch
+}
+
+// IgnoreRuleMatch identifies a scoped ignore_attribute rule that contributed
+// to downgrading a resource to no-op. Populated by the filter preprocessing.
+type IgnoreRuleMatch struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Paths       []string `json:"paths,omitempty"`
 }
 
 // ParseResult contains the parsed plan data.

--- a/internal/scaffold/generate.go
+++ b/internal/scaffold/generate.go
@@ -183,5 +183,14 @@ defaults {
 
   # Uncomment to ignore cosmetic attribute changes:
   # ignore_attributes = ["tags", "tags_all"]
+
+  # Scoped ignore rules (CR-0035) — apply only when resource/module globs match.
+  # Useful when an attribute should be ignored for one provider but not others,
+  # e.g. azapi_resource.output (a computed read-back, not a user change):
+  # ignore_attribute "azapi_output" {
+  #   description = "azapi computed refresh"
+  #   resource    = ["azapi_resource"]
+  #   attributes  = ["output"]
+  # }
 }
 `

--- a/testdata/e2e/ignore-attributes-scoped/.tfclassify.hcl
+++ b/testdata/e2e/ignore-attributes-scoped/.tfclassify.hcl
@@ -1,0 +1,37 @@
+classification "standard" {
+  description = "Standard review required"
+
+  rule {
+    resource = ["*"]
+    actions  = ["update", "create", "delete"]
+  }
+}
+
+classification "auto" {
+  description = "Auto-approved — cosmetic or computed-only changes"
+
+  rule {
+    resource = ["*"]
+    actions  = ["no-op"]
+  }
+  rule {
+    resource = ["*"]
+    actions  = ["read"]
+  }
+}
+
+precedence = ["standard", "auto"]
+
+defaults {
+  unclassified      = "standard"
+  no_changes        = "auto"
+  ignore_attributes = ["tags"]
+
+  # CR-0035: scoped rule — ignore azapi_resource's computed output attribute,
+  # which refreshes on every plan and is not a user-authored change.
+  ignore_attribute "azapi_output" {
+    description = "azapi_resource.output is a computed read-back of the API response; not a user change."
+    resource    = ["azapi_resource"]
+    attributes  = ["output"]
+  }
+}

--- a/testdata/e2e/ignore-attributes-scoped/expected.json
+++ b/testdata/e2e/ignore-attributes-scoped/expected.json
@@ -1,0 +1,5 @@
+{
+  "create": { "exit_code": 1, "classification": "standard" },
+  "destroy": { "exit_code": 1, "classification": "standard" },
+  "plan_only": true
+}

--- a/testdata/e2e/ignore-attributes-scoped/fixtures/create.json
+++ b/testdata/e2e/ignore-attributes-scoped/fixtures/create.json
@@ -1,0 +1,102 @@
+{
+  "format_version": "1.2",
+  "terraform_version": "1.13.0",
+  "resource_changes": [
+    {
+      "address": "azurerm_resource_group.tagged",
+      "mode": "managed",
+      "type": "azurerm_resource_group",
+      "name": "tagged",
+      "provider_name": "registry.terraform.io/hashicorp/azurerm",
+      "change": {
+        "actions": ["update"],
+        "before": {
+          "name": "rg-demo",
+          "location": "westeurope",
+          "tags": {
+            "environment": "prod",
+            "managedBy": "terraform"
+          }
+        },
+        "after": {
+          "name": "rg-demo",
+          "location": "westeurope",
+          "tags": {
+            "environment": "prod",
+            "managedBy": "terraform",
+            "tf-module-l2": "L2:aiwz:3.0.9"
+          }
+        },
+        "after_unknown": {},
+        "before_sensitive": {"tags": {}},
+        "after_sensitive": {"tags": {}}
+      }
+    },
+    {
+      "address": "azapi_resource.cognitive",
+      "mode": "managed",
+      "type": "azapi_resource",
+      "name": "cognitive",
+      "provider_name": "registry.terraform.io/azure/azapi",
+      "change": {
+        "actions": ["update"],
+        "before": {
+          "name": "cog-demo",
+          "type": "Microsoft.CognitiveServices/accounts@2025-06-01",
+          "tags": {
+            "environment": "prod",
+            "managedBy": "terraform"
+          },
+          "output": {
+            "id": "/subscriptions/xxx/resourceGroups/rg-demo/providers/Microsoft.CognitiveServices/accounts/cog-demo",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "endpoint": "https://cog-demo.openai.azure.com/"
+            }
+          }
+        },
+        "after": {
+          "name": "cog-demo",
+          "type": "Microsoft.CognitiveServices/accounts@2025-06-01",
+          "tags": {
+            "environment": "prod",
+            "managedBy": "terraform",
+            "tf-module-l2": "L2:aiwz:3.0.9"
+          },
+          "output": null
+        },
+        "after_unknown": {"output": true},
+        "before_sensitive": {"tags": {}},
+        "after_sensitive": {"tags": {}}
+      }
+    },
+    {
+      "address": "azurerm_storage_account.real",
+      "mode": "managed",
+      "type": "azurerm_storage_account",
+      "name": "real",
+      "provider_name": "registry.terraform.io/hashicorp/azurerm",
+      "change": {
+        "actions": ["update"],
+        "before": {
+          "name": "stdemo001",
+          "account_replication_type": "LRS",
+          "tags": {
+            "environment": "prod"
+          }
+        },
+        "after": {
+          "name": "stdemo001",
+          "account_replication_type": "GRS",
+          "tags": {
+            "environment": "prod",
+            "tf-module-l2": "L2:aiwz:3.0.9"
+          }
+        },
+        "after_unknown": {},
+        "before_sensitive": {"tags": {}},
+        "after_sensitive": {"tags": {}}
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds a repeatable `ignore_attribute "name" { ... }` block inside `defaults {}` that scopes an ignore rule to `resource` / `module` globs. Upgrades attribute-path matching from bare prefixes to per-segment globs (`tags.temp_*`, `properties.*.createdAt`). Existing `ignore_attributes = [...]` keeps working unchanged and composes additively with the new blocks.

## Why

CR-0034's `ignore_attributes` is global. Real-world use case: `azapi_resource.output` is a computed read-back that flips to `(known after apply)` on every plan — not a user-authored change. Adding `"output"` to the global list silences the noise but hides `output` on every other provider that happens to use the name. There was no way to say "ignore this attribute on this resource type only."

## Value

- Precise ignore rules without global blast radius — one scoped block per provider quirk.
- Attribute-path globs close a second gap (nested/indexed keys like `properties.*.createdAt`).
- Every downgrade is attributed to a named, described rule in text/JSON/SARIF/explain/evidence output, so audit readers see *why* without cross-referencing config.
- Fully additive: existing configs keep working.

## Usage

```hcl
defaults {
  unclassified      = "standard"
  no_changes        = "auto"
  ignore_attributes = ["tags"]                 # still global — unchanged

  ignore_attribute "azapi_output" {
    description = "azapi_resource.output is a computed read-back of the API response; not a user change."
    resource    = ["azapi_resource"]
    attributes  = ["output"]
  }

  ignore_attribute "transient_timestamps" {
    description = "API-assigned timestamps nested anywhere in properties."
    resource    = ["azapi_*"]
    attributes  = ["properties.*.createdAt", "properties.*.updatedAt"]
  }
}
```

For the driving real-world plan (19 tag-only updates + 2 azapi computed refreshes + 2 genuine diagnostic_setting changes), this routes the 21 cosmetic resources to `auto` and keeps the 2 real changes on `standard` — exactly the intended review split.

## Verification

- `make ci` green (build-all, test, vet, lint, govulncheck).
- All 17 e2e fixtures pass, including the new `testdata/e2e/ignore-attributes-scoped/` scenario.
- New unit coverage in `internal/classify/attribute_filter_test.go` for scoped matches, path globs (tail / mid / leading wildcards), union with the global list, and bare-prefix back-compat.
- New validation fixtures reject missing description, empty attributes, duplicate names, and uncompilable globs.
