### PR TITLE
feat: skip no-op rule evaluation

### DIFF
--- a/PR.md
+++ b/PR.md
@@ -1,0 +1,85 @@
+# CR-0036: Skip classification rule evaluation for no-op resources
+
+## What
+
+No-op resource changes (`actions = ["no-op"]`) now short-circuit in the classifier: they bypass rule iteration, inherit `defaults.no_changes`, and get a synthetic matched-rule description. Overall classification and text-output breakdown already exclude them; this makes the bypass the primary path instead of a workaround.
+
+## Why
+
+Since **CR-0034** (`ignore_attributes`), tag-only updates get downgraded to `["no-op"]` — routinely. The classifier still evaluated rules over them, so any rule without an explicit `not_actions = ["no-op"]` silently matched and elevated `Overall`. The text renderer hid the no-op resources from view, so the output looked like this:
+
+```
+Classification: major
+Resources: 1
+[minor] (1 resources)
+  - data.azapi_resource_action.account_keys[0] (azapi_resource_action) [read]
+(95 no-op resources hidden)
+```
+
+`major` — with zero visible major resources. The output was lying.
+
+Every one of the 16 e2e configs in this repo carried the same workaround rule to absorb no-ops at the lowest precedence — strong evidence the pattern was boilerplate the mental model imposed, not genuine configuration.
+
+## Value
+
+- **Honest output**: `Classification: minor` now means "the highest real change is minor". No mental translation through the filter.
+- **Zero boilerplate**: rule authors no longer need `not_actions = ["no-op"]` on every rule, and no longer need a catch-all `actions = ["no-op"]` rule.
+- **Transparency**: hidden no-op count is broken down by classification (`(95 no-op resources hidden — major: 4, minor: 91)`) so authors can sanity-check what the filter absorbed.
+- **Backward compatible**: existing configs with the workaround rule still parse and run. The rule just becomes dead code.
+
+## Usage
+
+Before (required workaround):
+
+```hcl
+classification "major" {
+  rule {
+    resource    = ["azurerm_key_vault_key"]
+    not_actions = ["no-op"]   # boilerplate to dodge cosmetic matches
+  }
+}
+
+classification "auto" {
+  rule {
+    resource = ["*"]
+    actions  = ["no-op"]   # catch-all to absorb no-ops
+  }
+}
+```
+
+After:
+
+```hcl
+classification "major" {
+  rule {
+    resource = ["azurerm_key_vault_key"]
+  }
+}
+
+classification "auto" {
+  description = "No approval needed"
+  # no rules — no-op resources short-circuit here via defaults.no_changes
+}
+
+defaults {
+  no_changes        = "auto"
+  ignore_attributes = ["tags", "tags_all"]
+}
+```
+
+## Scope
+
+- `classifyResource` and `explainResource` short-circuit on `isNoOp(change.Actions)`.
+- `Classify` and `AddPluginDecisions` continue to exclude no-op decisions from `Overall` (defense in depth for plugin decisions).
+- Text output: per-classification breakdown of hidden no-op counts.
+- Validator exempts the classification referenced by `defaults.no_changes` from the "has no rules" warning.
+- Workaround rule removed from all 16 e2e configs and the full-reference example; `newTestConfig` updated.
+- CR-0034 gets a follow-up note pointing at CR-0036.
+
+## Verification
+
+- `make ci` — build, test, vet, lint, govulncheck all pass.
+- `bash testdata/e2e/run.sh --build --fixtures` — 16/16 pass after workaround removal.
+- New tests: `TestClassifyResource_NoOpShortCircuit`, `TestClassifyResource_NativeNoOp`, `TestExplainClassify_NoOpSingleTraceEntry`, `TestClassify_NoOpDoesNotElevateOverall`, `TestFormatText_MixedNoOpBreakdownVerbose`.
+
+Full spec: `docs/cr/CR-0036-skip-noop-rule-evaluation.md`.

--- a/PR.md
+++ b/PR.md
@@ -2,7 +2,7 @@
 
 ## What
 
-No-op resource changes (`actions = ["no-op"]`) now short-circuit in the classifier: they bypass rule iteration, inherit `defaults.no_changes`, and get a synthetic matched-rule description. Overall classification and text-output breakdown already exclude them; this makes the bypass the primary path instead of a workaround.
+No-op resource changes (`actions = ["no-op"]`) now short-circuit in the classifier: they bypass rule iteration, inherit `defaults.no_changes`, and get a synthetic matched-rule description. Downgraded resources remain diagnosable in the output — verbose mode lists them in full; compact mode splits the hidden count between `ignore_attributes` downgrades and native no-ops.
 
 ## Why
 
@@ -24,7 +24,8 @@ Every one of the 16 e2e configs in this repo carried the same workaround rule to
 
 - **Honest output**: `Classification: minor` now means "the highest real change is minor". No mental translation through the filter.
 - **Zero boilerplate**: rule authors no longer need `not_actions = ["no-op"]` on every rule, and no longer need a catch-all `actions = ["no-op"]` rule.
-- **Transparency**: hidden no-op count is broken down by classification (`(95 no-op resources hidden — major: 4, minor: 91)`) so authors can sanity-check what the filter absorbed.
+- **Diagnosable**: verbose output shows every downgraded resource with its original action, the attribute paths the filter absorbed, and the synthetic matched rule — no need to drop to `tfclassify explain` for the common case.
+- **CI-friendly**: compact output surfaces the downgrade footprint as a single count line so logs stay tight, with a hint pointing to `-v` when detail is wanted.
 - **Backward compatible**: existing configs with the workaround rule still parse and run. The rule just becomes dead code.
 
 ## Usage
@@ -67,19 +68,72 @@ defaults {
 }
 ```
 
+Verbose output against a plan with one real data-source read, two tag-only downgrades, and one native no-op:
+
+```
+Classification: minor
+  Plumbing
+Exit code: 1
+Resources: 1
+
+[minor] (1 resources)
+  Plumbing
+  - module.aiwz.data.azapi_resource_action.account_keys[0] (azapi_resource_action) [read]
+    Rule: Data reads
+
+Downgraded to no-op by ignore_attributes (2):
+  - module.aiwz.azurerm_key_vault_key.cmk (azurerm_key_vault_key)
+    Originally: [update]  (ignored: tags.tf-module-l2)
+    Rule: no-op (downgraded by ignore_attributes: tags.tf-module-l2)
+  - module.aiwz.azurerm_resource_group.ai_app (azurerm_resource_group)
+    Originally: [update]  (ignored: tags.tf-module-l2)
+    Rule: no-op (downgraded by ignore_attributes: tags.tf-module-l2)
+
+(1 native no-op resources hidden)
+```
+
+Compact output (same plan):
+
+```
+Classification: minor
+Exit code: 1
+Resources: 1
+
+  [minor] module.aiwz.data.azapi_resource_action.account_keys[0]
+  (3 no-op resources hidden — 2 downgraded by ignore_attributes, 1 native; rerun with -v for detail)
+```
+
 ## Scope
 
 - `classifyResource` and `explainResource` short-circuit on `isNoOp(change.Actions)`.
 - `Classify` and `AddPluginDecisions` continue to exclude no-op decisions from `Overall` (defense in depth for plugin decisions).
-- Text output: per-classification breakdown of hidden no-op counts.
+- Verbose text output: dedicated "Downgraded to no-op by ignore_attributes" section per resource, plus a native-no-op count line.
+- Compact text output: split count between downgrades and native no-ops, with a rerun-verbose hint when downgrades exist.
 - Validator exempts the classification referenced by `defaults.no_changes` from the "has no rules" warning.
 - Workaround rule removed from all 16 e2e configs and the full-reference example; `newTestConfig` updated.
 - CR-0034 gets a follow-up note pointing at CR-0036.
 
-## Verification
+## Test Coverage
 
-- `make ci` — build, test, vet, lint, govulncheck all pass.
+Classifier (`internal/classify/classifier_test.go`):
+
+- `TestClassifyResource_NoOpShortCircuit` — downgraded no-op inherits `defaults.no_changes`, synthetic rule references `ignore_attributes` and the ignored path, and does not reference the major rule that would otherwise match the type.
+- `TestClassifyResource_NativeNoOp` — native no-op gets `"no-op (no change)"` synthetic rule.
+- `TestExplainClassify_NoOpSingleTraceEntry` — explain emits exactly one synthetic trace entry instead of iterating rules.
+- `TestClassify_NoOpDoesNotElevateOverall` — no-op decisions do not raise `Overall` above the highest real classification.
+- `TestClassify_AllNoOpReportsNoChanges` and `TestClassify_MixedNoOpAndRealNotNoChanges` continue to pass against the updated `newTestConfig` (auto classification has no rules).
+
+Text output (`internal/output/formatter_test.go`):
+
+- `TestFormatText_DowngradedSectionVerbose` — verbose output renders the "Downgraded to no-op by ignore_attributes (N):" header with per-resource address, type, original actions, ignored paths, and synthetic rule; native no-ops collapse into a count line and are not listed per-resource.
+- `TestFormatText_HiddenCountSplitCompact` — compact line splits "X downgraded by ignore_attributes, Y native" with the rerun hint.
+- `TestFormatText_HiddenCountOnlyDowngradedCompact` — only downgrades → "downgraded by ignore_attributes; rerun with -v".
+- `TestFormatText_HiddenCountOnlyNativeCompact` — only native no-ops → "native", no `ignore_attributes` mention, no rerun hint.
+- `TestFormatText_NoChangesWithDowngradedVerbose` and `TestFormatText_NoChangesWithDowngradedNonVerbose` — pre-existing all-no-op cases continue to pass.
+
+End-to-end:
+
+- `make ci` green (build, test, vet, golangci-lint, govulncheck).
 - `bash testdata/e2e/run.sh --build --fixtures` — 16/16 pass after workaround removal.
-- New tests: `TestClassifyResource_NoOpShortCircuit`, `TestClassifyResource_NativeNoOp`, `TestExplainClassify_NoOpSingleTraceEntry`, `TestClassify_NoOpDoesNotElevateOverall`, `TestFormatText_MixedNoOpBreakdownVerbose`.
 
 Full spec: `docs/cr/CR-0036-skip-noop-rule-evaluation.md`.

--- a/README.md
+++ b/README.md
@@ -471,6 +471,8 @@ Downgraded to no-op by ignore_attributes:
 
 **No-changes detection:** when ALL resources in a plan are no-op (either natively or after `ignore_attributes` filtering), the overall classification uses the `no_changes` default with exit code 0.
 
+**Rule evaluation:** no-op resources bypass rule evaluation entirely. They receive the `defaults.no_changes` classification with a synthetic rule description referencing `ignore_attributes` (for downgraded resources) or `"no-op (no change)"` (for native Terraform no-ops). No-op resources do not contribute to the overall classification precedence. Rule authors therefore do NOT need to add `not_actions = ["no-op"]` to any rule — the short-circuit handles it uniformly.
+
 Only `["update"]` actions are evaluated — creates, deletes, and replacements are never affected.
 
 ### Blast Radius

--- a/docs/cr/CR-0034-ignore-attributes.md
+++ b/docs/cr/CR-0034-ignore-attributes.md
@@ -11,6 +11,13 @@ target-version: "0.7.0"
 
 # Ignore Attributes: Exclude Cosmetic Changes from Classification
 
+> **Follow-up (2026-04-21):** See **CR-0035** — the interaction between the
+> action rewriting introduced here and the rule engine produced misleading
+> Overall classifications for mixed plans. CR-0035 short-circuits rule
+> evaluation for `["no-op"]` resources so they bypass matching entirely and
+> inherit `defaults.no_changes`. Rule authors no longer need to add
+> `not_actions = ["no-op"]` or a catch-all `actions = ["no-op"]` rule.
+
 ## Change Summary
 
 Terraform plans frequently include resources whose only changes are to cosmetic attributes like provenance tags (e.g., `tf-module-l2` version bumps). These changes are semantically irrelevant but currently count as full "update" actions, inflating blast radius thresholds and triggering classification rules meant for meaningful infrastructure changes. This CR introduces a global `ignore_attributes` configuration that preprocesses the plan to downgrade cosmetic-only updates to `no-op`, making them invisible to blast radius counting and core rule matching while remaining visible in output with clear attribution.

--- a/docs/cr/CR-0034-ignore-attributes.md
+++ b/docs/cr/CR-0034-ignore-attributes.md
@@ -11,9 +11,9 @@ target-version: "0.7.0"
 
 # Ignore Attributes: Exclude Cosmetic Changes from Classification
 
-> **Follow-up (2026-04-21):** See **CR-0035** — the interaction between the
+> **Follow-up (2026-04-21):** See **CR-0036** — the interaction between the
 > action rewriting introduced here and the rule engine produced misleading
-> Overall classifications for mixed plans. CR-0035 short-circuits rule
+> Overall classifications for mixed plans. CR-0036 short-circuits rule
 > evaluation for `["no-op"]` resources so they bypass matching entirely and
 > inherit `defaults.no_changes`. Rule authors no longer need to add
 > `not_actions = ["no-op"]` or a catch-all `actions = ["no-op"]` rule.

--- a/docs/cr/CR-0035-skip-noop-rule-evaluation.md
+++ b/docs/cr/CR-0035-skip-noop-rule-evaluation.md
@@ -1,0 +1,472 @@
+---
+id: "CR-0035"
+status: "proposed"
+date: 2026-04-21
+requestor: Johan Karlsson
+stakeholders:
+  - Johan Karlsson
+priority: "high"
+target-version: "0.8.0"
+---
+
+# Skip Classification Rule Evaluation for No-Op Resource Changes
+
+## Change Summary
+
+CR-0034 introduced `ignore_attributes`, which downgrades cosmetic-only updates to `actions = ["no-op"]`. The classifier still evaluates classification rules against those no-op resources, so any rule without an explicit `not_actions = ["no-op"]` guard matches them and elevates `Overall` to a higher classification. This CR removes rule evaluation entirely for resources whose action set is exactly `["no-op"]` — they bypass rule matching and receive the `defaults.no_changes` classification with a synthetic rule description that explains why.
+
+## Motivation and Background
+
+Since CR-0034 made no-op resources common (every tag-only update produces one), every new rule needs boilerplate to avoid matching cosmetic resources. Rule authors typically don't discover this until they see output like `Classification: major, Resources: 1, (95 no-op resources hidden)` and can't explain what drove `major`.
+
+The current workaround has two forms, both present in the codebase:
+
+1. Add `not_actions = ["no-op"]` to every rule that matches all actions. This is boilerplate with no information value — "no-op" means nothing happens; no rule should match it by default.
+2. Add a catch-all `rule { resource = ["*"], actions = ["no-op"] }` at the lowest-precedence classification so no-op resources fall into it. **All 16 e2e scenarios in this repository use this exact pattern**, which strongly indicates it is not genuine configuration but a tax the mental model imposes on rule authors.
+
+No-op means "nothing happens to this resource". Running classification rules over something that will not happen is semantically incoherent. The fact that it currently elevates `Overall` despite the resource being invisible in text output is actively misleading, as demonstrated by the original bug report ("the output lied").
+
+## Change Drivers
+
+* Rule authors must learn the `not_actions = ["no-op"]` pattern the hard way — failure mode is misleading output, not a config validation error
+* 16 of 16 e2e scenarios carry the same workaround rule, proving it is boilerplate
+* CR-0034's interaction with existing rules was incidental, not designed — no-op was rare before CR-0034 and common after
+* Output integrity: `Overall` reports a level that the visible resources cannot explain, eroding trust in the tool
+
+## Current State
+
+`internal/classify/classifier.go:classifyResource` iterates precedence-ordered rules and returns the first match:
+
+```go
+for _, classificationName := range c.config.Precedence {
+    rules := c.matchers[classificationName]
+    for _, rule := range rules {
+        if rule.matchesResource(change.Type) &&
+           rule.matchesActions(change.Actions) &&
+           rule.matchesModule(change.ModuleAddress) {
+            decision.Classification = classificationName
+            ...
+            return decision
+        }
+    }
+}
+```
+
+`matchesActions` returns `true` for any rule without an explicit `actions` or `not_actions` field:
+
+```go
+if len(r.actions) > 0 { ... }
+if len(r.notActions) > 0 { ... }
+return true  // matches all actions, including "no-op"
+```
+
+A tag-only update downgraded by `FilterCosmeticChanges` therefore still matches rules intended for meaningful changes. The resource's classification feeds into `Overall` precedence, while the text formatter hides the resource because `isNoOpDecision` is true — producing an output that names a classification with no visible matched resources.
+
+### Current State Diagram
+
+```mermaid
+flowchart LR
+    subgraph Current["Current: no-op is evaluated like any other action"]
+        Change["ResourceChange<br/>actions: [no-op]"] --> Filter["FilterCosmeticChanges<br/>(already ran)"]
+        Filter --> Rules["classifyResource<br/>iterates rules"]
+        Rules -->|"rule with no action filter<br/>matches everything"| Match["Classification = major"]
+        Match --> Overall["Overall = max(precedence)"]
+        Match --> Hide["Text output hides<br/>(no-op resource)"]
+        Overall --> Report["'Classification: major'<br/>with 0 visible major resources"]
+        Hide --> Report
+    end
+```
+
+## Proposed Change
+
+Short-circuit rule evaluation for no-op resources at the top of `classifyResource` and `explainResource`. A resource whose action set is exactly `["no-op"]`:
+
+1. Bypasses all rule iteration
+2. Receives `defaults.no_changes` as its classification (the semantic equivalent of "this resource does nothing")
+3. Gets a synthetic `MatchedRules` entry describing why — either `"no-op (downgraded by ignore_attributes: <paths>)"` when `OriginalActions` is populated, or `"no-op (no change)"` for Terraform-native no-ops
+
+`Overall` precedence tracking continues to skip no-op decisions (defense in depth; no-op resources never contribute to `Overall` even if a plugin assigns them a user-defined classification).
+
+The universal `rule { resource = ["*"], actions = ["no-op"] }` workaround becomes dead code. It remains valid syntax — this CR does not remove the `actions` or `not_actions` rule fields — but it is redundant, and the e2e configs and test helper should be cleaned up to reflect the new baseline.
+
+### Proposed State Diagram
+
+```mermaid
+flowchart LR
+    subgraph Proposed["Proposed: no-op bypasses rules entirely"]
+        Change["ResourceChange<br/>actions: [no-op]"] --> Check{"isNoOp(actions)?"}
+        Check -->|"yes"| Short["Short-circuit:<br/>classification = defaults.no_changes<br/>matched_rules = synthetic"]
+        Check -->|"no"| Rules["classifyResource<br/>iterates rules"]
+        Short --> Decision["ResourceDecision<br/>(does not elevate Overall)"]
+        Rules --> Decision
+        Decision --> Overall["Overall = max(precedence) over<br/>non-no-op decisions"]
+    end
+```
+
+## Requirements
+
+### Functional Requirements
+
+1. The system **MUST** skip all classification rule evaluation for any resource whose `Actions` field is exactly `["no-op"]`
+2. The system **MUST** assign `defaults.no_changes` as the `Classification` for any resource whose `Actions` field is exactly `["no-op"]`
+3. The system **MUST** populate `ClassificationDescription` with the description of `defaults.no_changes` for no-op resources
+4. The system **MUST** record a synthetic `MatchedRules` entry describing why the resource was not evaluated against rules
+5. The synthetic rule description **MUST** reference `ignore_attributes` and list the ignored paths when the resource's `OriginalActions` field is populated
+6. The synthetic rule description **MUST** read `"no-op (no change)"` when the resource has no `OriginalActions` (native Terraform no-op)
+7. The system **MUST** exclude no-op resources from the `Overall` precedence calculation in `Classify`
+8. The system **MUST** exclude no-op resources from the `Overall` precedence recalculation in `AddPluginDecisions`
+9. The `tfclassify explain` command **MUST** emit a single synthetic trace entry for no-op resources instead of evaluating each rule against them
+10. The text output **MUST** present the hidden no-op count broken down by classification so rule authors can see what the filter absorbed
+
+### Non-Functional Requirements
+
+1. The system **MUST NOT** require rule authors to add `not_actions = ["no-op"]` to any rule to prevent no-op matching
+2. The system **MUST NOT** require a catch-all `actions = ["no-op"]` rule to classify no-op resources
+3. The change **MUST** preserve backward compatibility with existing configs — configs containing the workaround rule continue to parse and validate without errors, but the workaround rule never matches (it is dead, not invalid)
+4. The short-circuit **MUST** execute before any rule iteration to avoid wasted work on plans containing many no-op resources
+
+## Affected Components
+
+* `internal/classify/classifier.go` — Short-circuit logic in `classifyResource` and `explainResource`
+* `internal/classify/classifier_test.go` — Update `newTestConfig` to remove the workaround `actions = ["no-op"]` rule; add tests for the short-circuit
+* `internal/output/formatter.go` — No-op breakdown by classification (applied as interim fix; consolidated here)
+* `internal/output/formatter_test.go` — Tests for the breakdown
+* `testdata/e2e/*/.tfclassify.hcl` — Remove the universal `rule { resource = ["*"], actions = ["no-op"] }` workaround from all 16 scenarios
+* `docs/cr/CR-0034-ignore-attributes.md` — Follow-up note that CR-0035 removes the need for explicit no-op rules
+* `docs/examples/full-reference/.tfclassify.hcl` — Remove the workaround if present
+* `README.md` — Document that no-op resources bypass rule evaluation
+
+## Scope Boundaries
+
+### In Scope
+
+* Short-circuit of rule evaluation for resources with `actions = ["no-op"]` in both `classifyResource` and `explainResource`
+* Synthetic matched-rule descriptions for downgraded and native no-op cases
+* Defense-in-depth skip of no-op decisions in `Overall` precedence tracking (`Classify` and `AddPluginDecisions`)
+* Text-output breakdown of the hidden no-op count by classification
+* Cleanup of the workaround rule from all 16 e2e scenarios and the test-helper config
+* Unit tests for the short-circuit behavior, synthetic rule descriptions, and Overall exclusion
+* E2E fixture verification that all 16 scenarios still pass after workaround removal
+* Reproduction test for the original bug report (`azurerm_key_vault_key` tag-only update + data-source read → `Overall = minor`)
+
+### Out of Scope ("Here, But Not Further")
+
+* Deprecation or removal of the `actions` or `not_actions` rule fields — both remain valid; they simply no longer need `"no-op"` as a value
+* Plugin-side short-circuit — plugins continue to receive no-op resources via gRPC and may emit decisions for them; host-side `Overall` skip prevents plugin decisions on no-op resources from elevating `Overall`
+* Changes to `FilterCosmeticChanges` or the `ignore_attributes` mechanism itself — orthogonal to this CR
+* Blast radius analyzer — already correctly skips no-op resources (pre-existing behavior per CR-0034)
+* Topology analyzer — already correctly skips no-op resources (`TestTopologyAnalyzer_SkipsNoOp`)
+* Removal of existing workaround rules from user configs outside the repository — documented as optional cleanup, not enforced
+
+## Alternative Approaches Considered
+
+* **Require rule authors to add `not_actions = ["no-op"]` explicitly.** Rejected. Universal boilerplate with no information value. Failure mode is silent misclassification, not a validation error. Violates the principle that the common path should not need ceremony.
+
+* **Emit a hard-coded `no-op` classification that users cannot configure.** Rejected. `defaults.no_changes` already expresses the semantic ("this contributes nothing to the plan") and is under user control. Introducing a parallel reserved classification fragments the model.
+
+* **Add a lint warning when rules don't have `not_actions = ["no-op"]`.** Rejected. Treats the workaround as correct and pushes the burden onto authors. Leaves the misleading-output problem intact for anyone who ignores the warning.
+
+* **Introduce a `pre_classify` hook pipeline that can filter resources before rule matching.** Rejected as over-engineering for a single well-defined case.
+
+* **Move the short-circuit to `FilterCosmeticChanges` and have it omit no-ops from the change slice entirely.** Rejected. Downstream consumers (explain, text output, evidence) need to see the no-op resources for visibility. The short-circuit must happen at classification, not filtering.
+
+## Impact Assessment
+
+### User Impact
+
+Rule authors no longer need to learn or apply the `not_actions = ["no-op"]` pattern. Output honesty improves: `Classification: minor` now means "the highest meaningful real change is minor" with no mental translation required. The breakdown line in text output (`(N no-op resources hidden — major: 3, minor: 92)`) gives rule authors enough information to sanity-check what the filter absorbed without re-running with `--verbose`.
+
+Users with existing configs see zero breaking change. The workaround rule (`rule { resource = ["*"], actions = ["no-op"] }`) continues to parse and validate; it just never matches. Users can delete it at their leisure.
+
+### Technical Impact
+
+* **Classifier core**: Five lines of short-circuit at the top of `classifyResource`. Same in `explainResource`. No new types, no new config fields, no new SDK fields.
+* **Plugins**: Plugins continue to receive no-op resources via gRPC `GetResourceChanges` and may call `EmitDecision` for them. Host-side `Overall` skip (interim fix, kept as defense in depth) prevents any such decisions from elevating `Overall`. This is an intentional conservative choice.
+* **Output formats**: The text output has a new breakdown line when hidden no-ops span multiple classifications. JSON, GitHub Actions, SARIF, and evidence artifacts are unchanged — they already include the full per-resource decision list so consumers can derive their own breakdowns.
+* **Backward compatibility**: No breaking changes. Existing configs parse and run identically. Existing no-op rules become dead code; no error, no warning required.
+
+### Business Impact
+
+Reduces adoption friction for tfclassify in environments where CR-0034 is configured (i.e., most real-world Azure deployments with module tagging). Restores `Overall` to an auditable signal, which is a prerequisite for using tfclassify for approval routing.
+
+## Implementation Approach
+
+### Phase 1: Classifier Short-Circuit
+
+1. Add `isNoOp(change.Actions)` check at the top of `classifyResource`
+2. Build the synthetic decision: `Classification = defaults.no_changes`, `MatchedRules = [<synthetic>]`, `ClassificationDescription` looked up from the description map
+3. Return the decision without iterating rules
+4. Mirror the short-circuit in `explainResource`: emit one `TraceEntry` with `Source = "core-rule"`, `Result = TraceMatch`, `Rule = <synthetic>`, and `Classification = defaults.no_changes`
+
+### Phase 2: Defense-in-Depth Overall Skip
+
+Already applied as interim fix. Consolidate and document:
+
+1. `Classify` skips `isNoOp(change.Actions)` when tracking highest precedence
+2. `AddPluginDecisions` skips `isNoOp(decision.Actions)` when recalculating `Overall`
+
+### Phase 3: Output Transparency
+
+Already applied as interim fix. Consolidate and document:
+
+1. Verbose and compact text output produce `(N no-op resources hidden — <classification>: <count>, ...)` when there are no-ops across multiple classifications
+2. Fall back to `(N no-op resources hidden)` when all hidden no-ops share a single classification
+
+### Phase 4: Cleanup
+
+1. Remove the `rule { resource = ["*"], actions = ["no-op"] }` block from all 16 e2e configs
+2. Remove the corresponding rule from `newTestConfig` in `classifier_test.go`
+3. Verify all e2e fixtures and unit tests still pass
+4. Append a follow-up note to CR-0034 pointing to CR-0035
+5. Update `README.md` section on ignore_attributes to state no-op resources bypass rule evaluation
+
+### Implementation Flow
+
+```mermaid
+flowchart LR
+    subgraph Phase1["Phase 1: Short-Circuit"]
+        A1[classifyResource: isNoOp check] --> A2[Build synthetic decision]
+        A2 --> A3[explainResource: same pattern]
+    end
+    subgraph Phase2["Phase 2: Overall Skip"]
+        B1[Classify skip] --> B2[AddPluginDecisions skip]
+    end
+    subgraph Phase3["Phase 3: Output"]
+        C1[Text breakdown verbose] --> C2[Text breakdown compact]
+    end
+    subgraph Phase4["Phase 4: Cleanup"]
+        D1[Remove e2e workaround rules] --> D2[Update newTestConfig]
+        D2 --> D3[Update docs]
+    end
+    Phase1 --> Phase2 --> Phase3 --> Phase4
+```
+
+## Test Strategy
+
+### Tests to Add
+
+| Test File | Test Name | Description | Inputs | Expected Output |
+|-----------|-----------|-------------|--------|-----------------|
+| `internal/classify/classifier_test.go` | `TestClassifyResource_NoOpShortCircuit` | Tag-downgraded no-op short-circuits to no_changes default | ResourceChange with `Actions=["no-op"]`, `OriginalActions=["update"]`, `IgnoredAttributes=["tags.tf-module-l2"]`; type matches a major rule | `Classification=defaults.no_changes`, `MatchedRules` references `ignore_attributes` and `tags.tf-module-l2` |
+| `internal/classify/classifier_test.go` | `TestClassifyResource_NativeNoOp` | Native Terraform no-op short-circuits to no_changes default | ResourceChange with `Actions=["no-op"]`, no `OriginalActions` | `Classification=defaults.no_changes`, `MatchedRules` equals `["no-op (no change)"]` |
+| `internal/classify/classifier_test.go` | `TestClassifyResource_NoOpDoesNotMatchMajorRule` | Verify a type that would match a major rule does NOT get classified major when actions=["no-op"] | ResourceChange with type matching major rule, actions=["no-op"] | `Classification != "major"` |
+| `internal/classify/classifier_test.go` | `TestClassify_NoOpDoesNotElevateOverall` (already added as interim) | Overall reflects real changes, not no-ops | Tag-only no-op (major by rules) + data read (minor) | `Overall == "minor"` |
+| `internal/classify/classifier_test.go` | `TestExplainClassify_NoOpSingleTraceEntry` | Explain trace has one synthetic entry for no-op resources | Same inputs as `TestClassifyResource_NoOpShortCircuit` | `len(Trace) == 1`, `Trace[0].Rule` references `ignore_attributes` |
+| `internal/output/formatter_test.go` | `TestFormatText_MixedNoOpBreakdownVerbose` (already added as interim) | Hidden no-op count is broken down by classification | Mixed real + no-op decisions across classifications | Output contains `(N no-op resources hidden — <c>: <n>, ...)` |
+
+### Tests to Modify
+
+| Test File | Test Name | Current Behavior | New Behavior | Reason for Change |
+|-----------|-----------|------------------|--------------|-------------------|
+| `internal/classify/classifier_test.go` | `newTestConfig` | Includes the `auto { actions=["no-op"] }` workaround rule | Workaround rule removed; auto classification has no rules | The workaround is no longer needed; keeping it would mask the real behavior under test |
+| `internal/classify/classifier_test.go` | `TestClassify_AllNoOpReportsNoChanges` | Asserts that no-op resources match via the auto/no-op rule | Asserts they short-circuit to `defaults.no_changes` | Short-circuit replaces rule-based matching for no-op |
+
+### Tests to Remove
+
+Not applicable — no existing tests become obsolete; they either pass unchanged or are updated in the modify table above.
+
+## Acceptance Criteria
+
+### AC-1: No-op resources do not match classification rules
+
+```gherkin
+Given a classifier configured with a "major" rule matching resource "azurerm_key_vault_key"
+  And a ResourceChange with type "azurerm_key_vault_key" and Actions = ["no-op"]
+When the classifier processes the change
+Then the resource's Classification equals defaults.no_changes
+  And the resource's MatchedRules does not reference the "major" rule
+```
+
+### AC-2: Overall excludes no-op resources
+
+```gherkin
+Given a plan containing one "azurerm_key_vault_key" resource with Actions = ["no-op"] (cosmetic tag downgrade)
+  And one "azapi_resource_action" with Actions = ["read"] classified as "minor"
+  And a config where "azurerm_key_vault_key" would match a "major" rule for non-no-op actions
+When the classifier processes the plan
+Then Overall is "minor"
+  And the exit code corresponds to the "minor" classification
+```
+
+### AC-3: Synthetic rule reflects ignore_attributes downgrade
+
+```gherkin
+Given a ResourceChange with Actions = ["no-op"], OriginalActions = ["update"], and IgnoredAttributes = ["tags.tf-module-l2"]
+When the classifier processes the change
+Then the resource decision's MatchedRules contains a synthetic string that includes "ignore_attributes"
+  And the synthetic string includes "tags.tf-module-l2"
+```
+
+### AC-4: Native no-op resources are handled explicitly
+
+```gherkin
+Given a ResourceChange with Actions = ["no-op"] and no OriginalActions (Terraform-native no-op)
+When the classifier processes the change
+Then the resource decision's MatchedRules equals ["no-op (no change)"]
+```
+
+### AC-5: Workaround rule is no longer necessary
+
+```gherkin
+Given a .tfclassify.hcl config with no rule matching actions = ["no-op"]
+  And a plan containing cosmetic no-op resources
+When tfclassify runs
+Then the no-op resources are classified as defaults.no_changes
+  And Overall reflects only the real changes in the plan
+```
+
+### AC-6: Existing workaround configs remain valid
+
+```gherkin
+Given a .tfclassify.hcl config containing `rule { resource = ["*"], actions = ["no-op"] }`
+When tfclassify runs
+Then the config loads and validates without error
+  And the workaround rule never matches (dead, not broken)
+  And no warning is required
+```
+
+### AC-7: Explain shows a single trace entry for no-op resources
+
+```gherkin
+Given a ResourceChange with Actions = ["no-op"]
+When tfclassify explain processes it
+Then the resource's Trace contains exactly one entry
+  And the entry's Result is "match"
+  And the entry's Classification is defaults.no_changes
+  And the entry's Rule contains a description of the short-circuit
+```
+
+### AC-8: Text output breaks down hidden no-op counts by classification
+
+```gherkin
+Given a plan with real changes across multiple classifications
+  And hidden no-op resources whose pre-short-circuit classification spans multiple values
+When tfclassify runs with default text output
+Then the output contains a line of the form "(N no-op resources hidden — <classification>: <count>, ...)"
+```
+
+## Quality Standards Compliance
+
+### Build & Compilation
+
+- [ ] `go build ./...` exits 0
+- [ ] No new compiler warnings
+
+### Linting & Code Style
+
+- [ ] `golangci-lint run ./...` reports 0 issues
+- [ ] Code follows existing conventions in `internal/classify/`
+
+### Test Execution
+
+- [ ] `go test ./...` exits 0
+- [ ] New tests pass on first run
+- [ ] E2E fixture tests (`bash testdata/e2e/run.sh --build --fixtures`) report 16/16 pass
+
+### Documentation
+
+- [ ] CR-0034 updated with a follow-up note referencing CR-0035
+- [ ] README section on `ignore_attributes` updated to mention the short-circuit
+- [ ] Synthetic rule strings documented alongside the short-circuit code
+
+### Code Review
+
+- [ ] Changes submitted via pull request
+- [ ] PR title follows Conventional Commits format (`feat: ...` or `refactor: ...`)
+- [ ] Changes squash-merged to maintain linear history
+
+### Verification Commands
+
+```bash
+# Build
+make build-all
+
+# Lint + vet
+make lint
+make vet
+
+# Unit + integration tests
+make test
+
+# Full CI suite
+make ci
+
+# E2E fixtures
+bash testdata/e2e/run.sh --build --fixtures
+```
+
+## Risks and Mitigation
+
+### Risk 1: Users with explicit no-op rules see a behavior change
+
+**Likelihood:** low — most such rules follow the universal workaround pattern and their removal does not change outcomes
+**Impact:** low — dead rules are ignored silently; worst case is a config containing an unused rule
+**Mitigation:** No hard removal of the `actions = ["no-op"]` syntax; existing configs continue to parse. Document the deprecation in the CHANGELOG.
+
+### Risk 2: Plugin decisions on no-op resources become less meaningful
+
+**Likelihood:** low — no known plugins emit decisions for no-op resources today
+**Impact:** low — plugin decisions still merge into the per-resource decision list; only `Overall` elevation is blocked
+**Mitigation:** Overall-skip is the conservative default; can be revisited in a future CR if a legitimate plugin use case emerges
+
+### Risk 3: External tooling that parses `matched_rules` strings encounters new synthetic formats
+
+**Likelihood:** low — `matched_rules` is intended for human consumption
+**Impact:** low — synthetic strings follow a stable pattern and are additive, not replacing existing format
+**Mitigation:** Consumers that need structured data should use `OriginalActions` and `IgnoredAttributes` fields, not parse `matched_rules`
+
+### Risk 4: Short-circuit masks a misconfigured `defaults.no_changes` value
+
+**Likelihood:** medium — users who leave `no_changes` unset may see empty classifications
+**Impact:** low — resolves to the zero-value string `""` which fails precedence lookup gracefully
+**Mitigation:** Config validation already warns when `no_changes` is unset; reuse existing validation
+
+## Dependencies
+
+* Builds directly on CR-0034 (ignore_attributes) — this CR is a refinement of CR-0034's interaction with the rule engine
+* No external dependencies
+
+## Estimated Effort
+
+* Phase 1 (classifier short-circuit + explain): ~2 hours
+* Phase 2 (Overall skip consolidation): ~0 hours (interim fix already in place)
+* Phase 3 (text output breakdown): ~0 hours (interim fix already in place)
+* Phase 4 (cleanup + docs): ~2 hours
+* Testing + CI + e2e: ~1 hour
+
+Total: ~5 hours.
+
+## Decision Outcome
+
+Chosen approach: **short-circuit rule evaluation for resources with `actions = ["no-op"]` and assign `defaults.no_changes` as their classification**, because no-op already has a clear semantic meaning in the config model ("nothing happens to this resource") that maps directly to the existing `no_changes` default. This removes boilerplate without introducing new concepts.
+
+Alternative approaches either required rule authors to learn the workaround (status quo), introduced parallel reserved classifications (over-complicated), or added lint warnings (doesn't fix the misleading output). Only the short-circuit removes the root cause while preserving backward compatibility.
+
+## Implementation Status
+
+* **Started:** 2026-04-21
+* **Completed:** {to be filled in on implementation}
+* **Deployed to Production:** {to be filled in on release}
+* **Notes:** Interim fixes (Overall skip + text output breakdown) were applied to the worktree ahead of this CR while diagnosing the original bug report. This CR consolidates those fixes with the primary change (short-circuit in `classifyResource`) and the workaround cleanup.
+
+## Related Items
+
+* **CR-0034** — `ignore_attributes` (introduced `FilterCosmeticChanges`); this CR is its direct follow-up
+* **CR-0032** — `not_actions` rule field; the generic mechanism the current workaround relies on; unchanged by this CR
+* **CR-0030** — blast radius analyzer; already correctly skips no-op resources and requires no change
+* Original bug report: "the output lied" — the motivating scenario is a plan containing `azurerm_key_vault_key` tag-only updates plus a single data-source read, which produced `Classification: major` with one minor resource visible
+
+## More Information
+
+The universal workaround across the project's 16 e2e scenarios is identical boilerplate:
+
+```hcl
+classification "auto" {
+  rule {
+    resource = ["*"]
+    actions  = ["no-op"]
+  }
+}
+```
+
+The fact that every e2e config needs it — in a codebase maintained by the tool's author — is strong evidence that this is not configuration but mental-model overhead imposed by an accidental semantics. CR-0035 fixes the semantics so the workaround becomes unnecessary across the codebase and for downstream users.

--- a/docs/cr/CR-0035-skip-noop-rule-evaluation.md
+++ b/docs/cr/CR-0035-skip-noop-rule-evaluation.md
@@ -1,12 +1,12 @@
 ---
 id: "CR-0035"
-status: "proposed"
+status: "implemented"
 date: 2026-04-21
 requestor: Johan Karlsson
 stakeholders:
   - Johan Karlsson
 priority: "high"
-target-version: "0.8.0"
+target-version: "0.9.0"
 ---
 
 # Skip Classification Rule Evaluation for No-Op Resource Changes
@@ -445,9 +445,9 @@ Alternative approaches either required rule authors to learn the workaround (sta
 ## Implementation Status
 
 * **Started:** 2026-04-21
-* **Completed:** {to be filled in on implementation}
+* **Completed:** 2026-04-21
 * **Deployed to Production:** {to be filled in on release}
-* **Notes:** Interim fixes (Overall skip + text output breakdown) were applied to the worktree ahead of this CR while diagnosing the original bug report. This CR consolidates those fixes with the primary change (short-circuit in `classifyResource`) and the workaround cleanup.
+* **Notes:** All four implementation phases landed in a single worktree branch. Phase 1 (short-circuit in `classifyResource` and `explainResource`) is the load-bearing change. Phase 2 (Overall skip) was applied first as an interim fix during initial diagnosis; it remains as defense in depth for plugin decisions on no-op resources. Phase 3 (text output breakdown by classification) and Phase 4 (e2e config cleanup, CR-0034 follow-up note, README update, validator exemption for the `defaults.no_changes` classification) completed together. `make ci` passes; all 16 e2e fixture scenarios pass after removing the workaround rule from each.
 
 ## Related Items
 

--- a/docs/cr/CR-0036-skip-noop-rule-evaluation.md
+++ b/docs/cr/CR-0036-skip-noop-rule-evaluation.md
@@ -116,7 +116,9 @@ flowchart LR
 7. The system **MUST** exclude no-op resources from the `Overall` precedence calculation in `Classify`
 8. The system **MUST** exclude no-op resources from the `Overall` precedence recalculation in `AddPluginDecisions`
 9. The `tfclassify explain` command **MUST** emit a single synthetic trace entry for no-op resources instead of evaluating each rule against them
-10. The text output **MUST** present the hidden no-op count broken down by classification so rule authors can see what the filter absorbed
+10. The verbose text output (`--verbose`) **MUST** render a dedicated "Downgraded to no-op by ignore_attributes" section listing each downgraded resource with its address, original actions, ignored attribute paths, and the synthetic matched rule — users **MUST** be able to diagnose which rule matched and why without invoking `tfclassify explain`
+11. The compact text output **MUST** split the hidden no-op count between `ignore_attributes` downgrades and Terraform-native no-ops so CI logs surface the downgrade footprint
+12. The compact text output **MUST** include a hint directing users to `--verbose` when downgrades are present
 
 ### Non-Functional Requirements
 

--- a/docs/cr/CR-0036-skip-noop-rule-evaluation.md
+++ b/docs/cr/CR-0036-skip-noop-rule-evaluation.md
@@ -1,5 +1,5 @@
 ---
-id: "CR-0035"
+id: "CR-0036"
 status: "implemented"
 date: 2026-04-21
 requestor: Johan Karlsson
@@ -132,7 +132,7 @@ flowchart LR
 * `internal/output/formatter.go` — No-op breakdown by classification (applied as interim fix; consolidated here)
 * `internal/output/formatter_test.go` — Tests for the breakdown
 * `testdata/e2e/*/.tfclassify.hcl` — Remove the universal `rule { resource = ["*"], actions = ["no-op"] }` workaround from all 16 scenarios
-* `docs/cr/CR-0034-ignore-attributes.md` — Follow-up note that CR-0035 removes the need for explicit no-op rules
+* `docs/cr/CR-0034-ignore-attributes.md` — Follow-up note that CR-0036 removes the need for explicit no-op rules
 * `docs/examples/full-reference/.tfclassify.hcl` — Remove the workaround if present
 * `README.md` — Document that no-op resources bypass rule evaluation
 
@@ -217,7 +217,7 @@ Already applied as interim fix. Consolidate and document:
 1. Remove the `rule { resource = ["*"], actions = ["no-op"] }` block from all 16 e2e configs
 2. Remove the corresponding rule from `newTestConfig` in `classifier_test.go`
 3. Verify all e2e fixtures and unit tests still pass
-4. Append a follow-up note to CR-0034 pointing to CR-0035
+4. Append a follow-up note to CR-0034 pointing to CR-0036
 5. Update `README.md` section on ignore_attributes to state no-op resources bypass rule evaluation
 
 ### Implementation Flow
@@ -365,7 +365,7 @@ Then the output contains a line of the form "(N no-op resources hidden — <clas
 
 ### Documentation
 
-- [ ] CR-0034 updated with a follow-up note referencing CR-0035
+- [ ] CR-0034 updated with a follow-up note referencing CR-0036
 - [ ] README section on `ignore_attributes` updated to mention the short-circuit
 - [ ] Synthetic rule strings documented alongside the short-circuit code
 
@@ -469,4 +469,4 @@ classification "auto" {
 }
 ```
 
-The fact that every e2e config needs it — in a codebase maintained by the tool's author — is strong evidence that this is not configuration but mental-model overhead imposed by an accidental semantics. CR-0035 fixes the semantics so the workaround becomes unnecessary across the codebase and for downstream users.
+The fact that every e2e config needs it — in a codebase maintained by the tool's author — is strong evidence that this is not configuration but mental-model overhead imposed by an accidental semantics. CR-0036 fixes the semantics so the workaround becomes unnecessary across the codebase and for downstream users.

--- a/docs/examples/full-reference/.tfclassify.hcl
+++ b/docs/examples/full-reference/.tfclassify.hcl
@@ -257,10 +257,8 @@ classification "standard" {
   rule {
     description  = "All infrastructure changes not covered above"
     not_resource = ["*_monitor_*", "*_log_*", "*_diagnostic_*"]
-    not_actions  = ["no-op"]
-    # "not_actions" is the inverse of "actions". This rule matches everything
-    # EXCEPT no-op actions. Cannot combine "actions" and "not_actions" in the
-    # same rule. Valid values: "create", "update", "delete", "read", "no-op".
+    # No need for `not_actions = ["no-op"]` — CR-0035 short-circuits no-op
+    # resources to defaults.no_changes before rule evaluation runs.
     #
     # In practice, resources already matched by "critical" or "high" above
     # will never reach this rule due to precedence-ordered evaluation.
@@ -281,12 +279,10 @@ classification "auto" {
   description = "No approval needed"
   sarif_level = "none"
 
-  # No-op only: Terraform evaluated the resource but found no changes.
-  rule {
-    description = "No actual changes detected"
-    resource    = ["*"]
-    actions     = ["no-op"]
-  }
+  # No rules — the classification named by defaults.no_changes absorbs all
+  # no-op resources via short-circuit (CR-0035). Rule evaluation is skipped
+  # entirely for resources whose actions are exactly ["no-op"]; they receive
+  # this classification with a synthetic rule description explaining why.
 }
 
 # ─── Precedence ───────────────────────────────────────────────────────────────

--- a/docs/examples/full-reference/.tfclassify.hcl
+++ b/docs/examples/full-reference/.tfclassify.hcl
@@ -257,7 +257,7 @@ classification "standard" {
   rule {
     description  = "All infrastructure changes not covered above"
     not_resource = ["*_monitor_*", "*_log_*", "*_diagnostic_*"]
-    # No need for `not_actions = ["no-op"]` — CR-0035 short-circuits no-op
+    # No need for `not_actions = ["no-op"]` — CR-0036 short-circuits no-op
     # resources to defaults.no_changes before rule evaluation runs.
     #
     # In practice, resources already matched by "critical" or "high" above
@@ -280,7 +280,7 @@ classification "auto" {
   sarif_level = "none"
 
   # No rules — the classification named by defaults.no_changes absorbs all
-  # no-op resources via short-circuit (CR-0035). Rule evaluation is skipped
+  # no-op resources via short-circuit (CR-0036). Rule evaluation is skipped
   # entirely for resources whose actions are exactly ["no-op"]; they receive
   # this classification with a synthetic rule description explaining why.
 }

--- a/internal/classify/classifier.go
+++ b/internal/classify/classifier.go
@@ -57,13 +57,19 @@ func (c *Classifier) Classify(changes []plan.ResourceChange) *Result {
 		return result
 	}
 
-	// Classify each resource
+	// Classify each resource. Resources downgraded to no-op by
+	// FilterCosmeticChanges keep their classification for per-resource visibility
+	// but do NOT contribute to Overall — otherwise Overall can report e.g. "major"
+	// while every major-classified resource is hidden from the text output.
 	highestPrecedence := -1
 	for _, change := range changes {
 		decision := c.classifyResource(change)
 		result.ResourceDecisions = append(result.ResourceDecisions, decision)
 
-		// Track highest precedence classification
+		if isNoOp(change.Actions) {
+			continue
+		}
+
 		precedence := c.precedenceMap[decision.Classification]
 		if highestPrecedence == -1 || precedence < highestPrecedence {
 			highestPrecedence = precedence
@@ -430,10 +436,15 @@ func (c *Classifier) AddPluginDecisions(result *Result, pluginDecisions []Resour
 		}
 	}
 
-	// Recalculate overall (but not if all resources are no-op)
+	// Recalculate overall (but not if all resources are no-op). Skip no-op
+	// decisions so cosmetic-only resources do not elevate Overall — same
+	// rationale as in Classify().
 	if !result.NoChanges && len(result.ResourceDecisions) > 0 {
 		highestPrecedence := -1
 		for _, decision := range result.ResourceDecisions {
+			if isNoOp(decision.Actions) {
+				continue
+			}
 			precedence, known := c.precedenceMap[decision.Classification]
 			if !known {
 				continue

--- a/internal/classify/classifier.go
+++ b/internal/classify/classifier.go
@@ -4,6 +4,7 @@ package classify
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/jokarl/tfclassify/internal/config"
 	"github.com/jokarl/tfclassify/internal/plan"
@@ -102,6 +103,16 @@ func (c *Classifier) classifyResource(change plan.ResourceChange) ResourceDecisi
 		IgnoredAttributes: change.IgnoredAttributes,
 	}
 
+	// A resource whose only action is "no-op" does nothing. Running classification
+	// rules over something that will not happen is incoherent, so short-circuit to
+	// defaults.no_changes with a synthetic rule explaining why. See CR-0035.
+	if isNoOp(change.Actions) {
+		decision.Classification = c.config.Defaults.NoChanges
+		decision.ClassificationDescription = c.descriptionMap[decision.Classification]
+		decision.MatchedRules = []string{noOpRuleDescription(change)}
+		return decision
+	}
+
 	// Try each classification in precedence order
 	for _, classificationName := range c.config.Precedence {
 		rules := c.matchers[classificationName]
@@ -121,6 +132,20 @@ func (c *Classifier) classifyResource(change plan.ResourceChange) ResourceDecisi
 	decision.ClassificationDescription = c.descriptionMap[decision.Classification]
 	decision.MatchedRules = []string{"default (no rule matched)"}
 	return decision
+}
+
+// noOpRuleDescription builds the synthetic rule string attached to no-op
+// resources. Distinguishes ignore_attributes downgrades from native no-ops so
+// the output can surface which ignored paths absorbed the change.
+func noOpRuleDescription(change plan.ResourceChange) string {
+	if len(change.OriginalActions) == 0 {
+		return "no-op (no change)"
+	}
+	if len(change.IgnoredAttributes) == 0 {
+		return "no-op (downgraded by ignore_attributes)"
+	}
+	return fmt.Sprintf("no-op (downgraded by ignore_attributes: %s)",
+		strings.Join(change.IgnoredAttributes, ", "))
 }
 
 // getExitCode returns the exit code for a classification.
@@ -177,6 +202,21 @@ func (c *Classifier) explainResource(change plan.ResourceChange) ResourceExplana
 		Actions:           change.Actions,
 		OriginalActions:   change.OriginalActions,
 		IgnoredAttributes: change.IgnoredAttributes,
+	}
+
+	// No-op resources bypass rule iteration — emit a single synthetic trace
+	// entry describing the short-circuit. See CR-0035.
+	if isNoOp(change.Actions) {
+		explanation.Trace = append(explanation.Trace, TraceEntry{
+			Classification: c.config.Defaults.NoChanges,
+			Source:         "core-rule",
+			Rule:           noOpRuleDescription(change),
+			Result:         TraceMatch,
+			Reason:         "no-op short-circuit (rules not evaluated)",
+		})
+		explanation.FinalClassification = c.config.Defaults.NoChanges
+		explanation.FinalSource = "core-rule"
+		return explanation
 	}
 
 	// Track the best match (same logic as classifyResource, but evaluate all)

--- a/internal/classify/classifier.go
+++ b/internal/classify/classifier.go
@@ -105,7 +105,7 @@ func (c *Classifier) classifyResource(change plan.ResourceChange) ResourceDecisi
 
 	// A resource whose only action is "no-op" does nothing. Running classification
 	// rules over something that will not happen is incoherent, so short-circuit to
-	// defaults.no_changes with a synthetic rule explaining why. See CR-0035.
+	// defaults.no_changes with a synthetic rule explaining why. See CR-0036.
 	if isNoOp(change.Actions) {
 		decision.Classification = c.config.Defaults.NoChanges
 		decision.ClassificationDescription = c.descriptionMap[decision.Classification]
@@ -205,7 +205,7 @@ func (c *Classifier) explainResource(change plan.ResourceChange) ResourceExplana
 	}
 
 	// No-op resources bypass rule iteration — emit a single synthetic trace
-	// entry describing the short-circuit. See CR-0035.
+	// entry describing the short-circuit. See CR-0036.
 	if isNoOp(change.Actions) {
 		explanation.Trace = append(explanation.Trace, TraceEntry{
 			Classification: c.config.Defaults.NoChanges,

--- a/internal/classify/classifier_test.go
+++ b/internal/classify/classifier_test.go
@@ -29,7 +29,7 @@ func newTestConfig() *config.Config {
 				Name:        "auto",
 				Description: "Auto-approved",
 				// No rules — no-op resources short-circuit to defaults.no_changes;
-				// the workaround rule from before CR-0035 is no longer needed.
+				// the workaround rule from before CR-0036 is no longer needed.
 			},
 		},
 		Precedence: []string{"critical", "standard", "auto"},
@@ -436,7 +436,7 @@ func TestExplainClassify_AllRulesEvaluated(t *testing.T) {
 	}
 
 	// newTestConfig defines rules for "critical" and "standard" only;
-	// "auto" carries no rules post-CR-0035 (no-op resources short-circuit).
+	// "auto" carries no rules post-CR-0036 (no-op resources short-circuit).
 	res := result.Resources[0]
 	if len(res.Trace) != 2 {
 		t.Fatalf("expected 2 trace entries (one per rule), got %d", len(res.Trace))
@@ -963,7 +963,7 @@ func TestClassify_MixedNoOpAndRealNotNoChanges(t *testing.T) {
 	}
 }
 
-// CR-0035: a no-op resource whose type would match a higher-precedence rule
+// CR-0036: a no-op resource whose type would match a higher-precedence rule
 // must NOT be classified by that rule. Short-circuit assigns defaults.no_changes
 // and records a synthetic rule that describes the ignore_attributes downgrade.
 func TestClassifyResource_NoOpShortCircuit(t *testing.T) {
@@ -1024,7 +1024,7 @@ func TestClassifyResource_NoOpShortCircuit(t *testing.T) {
 	}
 }
 
-// CR-0035: a Terraform-native no-op (no OriginalActions) gets the
+// CR-0036: a Terraform-native no-op (no OriginalActions) gets the
 // "no-op (no change)" synthetic description.
 func TestClassifyResource_NativeNoOp(t *testing.T) {
 	cfg := &config.Config{
@@ -1057,7 +1057,7 @@ func TestClassifyResource_NativeNoOp(t *testing.T) {
 	}
 }
 
-// CR-0035: explain must emit exactly one synthetic trace entry for a no-op
+// CR-0036: explain must emit exactly one synthetic trace entry for a no-op
 // resource — the whole point is to NOT evaluate rules.
 func TestExplainClassify_NoOpSingleTraceEntry(t *testing.T) {
 	cfg := &config.Config{

--- a/internal/classify/classifier_test.go
+++ b/internal/classify/classifier_test.go
@@ -972,6 +972,64 @@ func TestClassify_MixedNoOpAndRealNotNoChanges(t *testing.T) {
 	}
 }
 
+// A no-op decision (post FilterCosmeticChanges) must not elevate Overall above
+// the real changes in the plan. Otherwise the text output says "major" while
+// all major-classified resources are hidden as no-op, forcing a rule author to
+// discover the `not_actions = ["no-op"]` workaround.
+func TestClassify_NoOpDoesNotElevateOverall(t *testing.T) {
+	cfg := &config.Config{
+		Classifications: []config.ClassificationConfig{
+			{
+				Name:        "major",
+				Description: "Core services",
+				Rules: []config.RuleConfig{
+					{Resource: []string{"azurerm_key_vault_key"}, Description: "Encryption keys"},
+				},
+			},
+			{
+				Name:        "minor",
+				Description: "Plumbing",
+				Rules: []config.RuleConfig{
+					{Resource: []string{"*"}, Actions: []string{"read"}, Description: "Data reads"},
+				},
+			},
+		},
+		Precedence: []string{"major", "minor"},
+		Defaults: &config.DefaultsConfig{
+			Unclassified: "major",
+			NoChanges:    "minor",
+		},
+	}
+
+	classifier, err := New(cfg)
+	if err != nil {
+		t.Fatalf("failed to create classifier: %v", err)
+	}
+
+	// A key_vault_key tag-only update that FilterCosmeticChanges downgraded to no-op,
+	// alongside a single data-source read.
+	changes := []plan.ResourceChange{
+		{
+			Address:           "azurerm_key_vault_key.cmk",
+			Type:              "azurerm_key_vault_key",
+			Actions:           []string{"no-op"},
+			OriginalActions:   []string{"update"},
+			IgnoredAttributes: []string{"tags.tf-module-l2"},
+		},
+		{
+			Address: "data.azapi_resource_action.account_keys[0]",
+			Type:    "azapi_resource_action",
+			Actions: []string{"read"},
+		},
+	}
+
+	result := classifier.Classify(changes)
+
+	if result.Overall != "minor" {
+		t.Errorf("expected Overall 'minor' (real change is the data read) — a no-op-downgraded resource should not elevate Overall; got %q", result.Overall)
+	}
+}
+
 func TestExplainClassify_AllNoOpReportsNoChanges(t *testing.T) {
 	cfg := newTestConfig()
 	classifier, err := New(cfg)

--- a/internal/classify/classifier_test.go
+++ b/internal/classify/classifier_test.go
@@ -1,6 +1,7 @@
 package classify
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/jokarl/tfclassify/internal/config"
@@ -27,9 +28,8 @@ func newTestConfig() *config.Config {
 			{
 				Name:        "auto",
 				Description: "Auto-approved",
-				Rules: []config.RuleConfig{
-					{Resource: []string{"*"}, Actions: []string{"no-op"}},
-				},
+				// No rules — no-op resources short-circuit to defaults.no_changes;
+				// the workaround rule from before CR-0035 is no longer needed.
 			},
 		},
 		Precedence: []string{"critical", "standard", "auto"},
@@ -435,18 +435,18 @@ func TestExplainClassify_AllRulesEvaluated(t *testing.T) {
 		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
 	}
 
-	// Should have trace entries for all 3 rules (critical, standard, auto)
+	// newTestConfig defines rules for "critical" and "standard" only;
+	// "auto" carries no rules post-CR-0035 (no-op resources short-circuit).
 	res := result.Resources[0]
-	if len(res.Trace) != 3 {
-		t.Fatalf("expected 3 trace entries (one per rule), got %d", len(res.Trace))
+	if len(res.Trace) != 2 {
+		t.Fatalf("expected 2 trace entries (one per rule), got %d", len(res.Trace))
 	}
 
-	// Verify all classifications appear
 	classifications := make(map[string]bool)
 	for _, entry := range res.Trace {
 		classifications[entry.Classification] = true
 	}
-	for _, name := range []string{"critical", "standard", "auto"} {
+	for _, name := range []string{"critical", "standard"} {
 		if !classifications[name] {
 			t.Errorf("expected trace entry for classification %q", name)
 		}
@@ -477,15 +477,6 @@ func TestExplainClassify_SkipReasons(t *testing.T) {
 	}
 	if res.Trace[0].Reason != "resource mismatch" {
 		t.Errorf("expected 'resource mismatch' reason, got %q", res.Trace[0].Reason)
-	}
-
-	// Auto rule should skip with action mismatch
-	autoEntry := res.Trace[2]
-	if autoEntry.Result != TraceSkip {
-		t.Errorf("expected auto rule to skip, got %s", autoEntry.Result)
-	}
-	if autoEntry.Reason == "" || autoEntry.Reason == "resource mismatch" {
-		t.Errorf("expected action mismatch reason, got %q", autoEntry.Reason)
 	}
 }
 
@@ -969,6 +960,147 @@ func TestClassify_MixedNoOpAndRealNotNoChanges(t *testing.T) {
 
 	if result.NoChanges {
 		t.Error("expected NoChanges to be false when some resources have real changes")
+	}
+}
+
+// CR-0035: a no-op resource whose type would match a higher-precedence rule
+// must NOT be classified by that rule. Short-circuit assigns defaults.no_changes
+// and records a synthetic rule that describes the ignore_attributes downgrade.
+func TestClassifyResource_NoOpShortCircuit(t *testing.T) {
+	cfg := &config.Config{
+		Classifications: []config.ClassificationConfig{
+			{
+				Name:        "major",
+				Description: "Core services",
+				Rules: []config.RuleConfig{
+					{Resource: []string{"azurerm_key_vault_key"}, Description: "Encryption keys"},
+				},
+			},
+			{
+				Name:        "minor",
+				Description: "Plumbing",
+			},
+		},
+		Precedence: []string{"major", "minor"},
+		Defaults: &config.DefaultsConfig{
+			Unclassified: "major",
+			NoChanges:    "minor",
+		},
+	}
+
+	classifier, err := New(cfg)
+	if err != nil {
+		t.Fatalf("failed to create classifier: %v", err)
+	}
+
+	change := plan.ResourceChange{
+		Address:           "azurerm_key_vault_key.cmk",
+		Type:              "azurerm_key_vault_key",
+		Actions:           []string{"no-op"},
+		OriginalActions:   []string{"update"},
+		IgnoredAttributes: []string{"tags.tf-module-l2"},
+	}
+
+	result := classifier.Classify([]plan.ResourceChange{change})
+
+	if len(result.ResourceDecisions) != 1 {
+		t.Fatalf("expected 1 decision, got %d", len(result.ResourceDecisions))
+	}
+	d := result.ResourceDecisions[0]
+	if d.Classification != "minor" {
+		t.Errorf("expected Classification = defaults.no_changes (minor), got %q", d.Classification)
+	}
+	if len(d.MatchedRules) != 1 {
+		t.Fatalf("expected 1 matched rule, got %d: %v", len(d.MatchedRules), d.MatchedRules)
+	}
+	if !strings.Contains(d.MatchedRules[0], "ignore_attributes") {
+		t.Errorf("expected synthetic rule to reference ignore_attributes, got %q", d.MatchedRules[0])
+	}
+	if !strings.Contains(d.MatchedRules[0], "tags.tf-module-l2") {
+		t.Errorf("expected synthetic rule to list the ignored attribute path, got %q", d.MatchedRules[0])
+	}
+	if strings.Contains(d.MatchedRules[0], "Encryption keys") {
+		t.Errorf("synthetic rule must not reference the major rule that would have matched the type, got %q", d.MatchedRules[0])
+	}
+}
+
+// CR-0035: a Terraform-native no-op (no OriginalActions) gets the
+// "no-op (no change)" synthetic description.
+func TestClassifyResource_NativeNoOp(t *testing.T) {
+	cfg := &config.Config{
+		Classifications: []config.ClassificationConfig{
+			{Name: "major", Rules: []config.RuleConfig{{Resource: []string{"*"}}}},
+			{Name: "minor"},
+		},
+		Precedence: []string{"major", "minor"},
+		Defaults:   &config.DefaultsConfig{Unclassified: "major", NoChanges: "minor"},
+	}
+	classifier, err := New(cfg)
+	if err != nil {
+		t.Fatalf("failed to create classifier: %v", err)
+	}
+
+	change := plan.ResourceChange{
+		Address: "azurerm_resource_group.rg",
+		Type:    "azurerm_resource_group",
+		Actions: []string{"no-op"},
+	}
+
+	result := classifier.Classify([]plan.ResourceChange{change})
+	d := result.ResourceDecisions[0]
+
+	if d.Classification != "minor" {
+		t.Errorf("expected Classification = defaults.no_changes (minor), got %q", d.Classification)
+	}
+	if len(d.MatchedRules) != 1 || d.MatchedRules[0] != "no-op (no change)" {
+		t.Errorf("expected [\"no-op (no change)\"], got %v", d.MatchedRules)
+	}
+}
+
+// CR-0035: explain must emit exactly one synthetic trace entry for a no-op
+// resource — the whole point is to NOT evaluate rules.
+func TestExplainClassify_NoOpSingleTraceEntry(t *testing.T) {
+	cfg := &config.Config{
+		Classifications: []config.ClassificationConfig{
+			{Name: "major", Rules: []config.RuleConfig{{Resource: []string{"azurerm_key_vault_key"}}}},
+			{Name: "minor", Rules: []config.RuleConfig{{Resource: []string{"*"}}}},
+		},
+		Precedence: []string{"major", "minor"},
+		Defaults:   &config.DefaultsConfig{Unclassified: "major", NoChanges: "minor"},
+	}
+	classifier, err := New(cfg)
+	if err != nil {
+		t.Fatalf("failed to create classifier: %v", err)
+	}
+
+	change := plan.ResourceChange{
+		Address:           "azurerm_key_vault_key.cmk",
+		Type:              "azurerm_key_vault_key",
+		Actions:           []string{"no-op"},
+		OriginalActions:   []string{"update"},
+		IgnoredAttributes: []string{"tags.tf-module-l2"},
+	}
+
+	result := classifier.ExplainClassify([]plan.ResourceChange{change})
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(result.Resources))
+	}
+	exp := result.Resources[0]
+	if len(exp.Trace) != 1 {
+		t.Fatalf("expected 1 trace entry (short-circuit), got %d: %v", len(exp.Trace), exp.Trace)
+	}
+	entry := exp.Trace[0]
+	if entry.Result != TraceMatch {
+		t.Errorf("expected TraceMatch, got %q", entry.Result)
+	}
+	if entry.Classification != "minor" {
+		t.Errorf("expected trace classification = minor, got %q", entry.Classification)
+	}
+	if !strings.Contains(entry.Rule, "ignore_attributes") {
+		t.Errorf("expected synthetic rule to reference ignore_attributes, got %q", entry.Rule)
+	}
+	if exp.FinalClassification != "minor" {
+		t.Errorf("expected FinalClassification = minor, got %q", exp.FinalClassification)
 	}
 }
 

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -419,10 +419,20 @@ func isCatchAllRule(rule RuleConfig) bool {
 }
 
 // warnEmptyClassifications warns when a classification has no rules and no plugin
-// analyzer blocks, meaning it can never match anything.
+// analyzer blocks, meaning it can never match anything. The classification
+// referenced by defaults.no_changes is exempt — CR-0035 routes no-op resources
+// to it via short-circuit, so it does not need rules.
 func warnEmptyClassifications(cfg *Config) []Warning {
+	var noChanges string
+	if cfg.Defaults != nil {
+		noChanges = cfg.Defaults.NoChanges
+	}
+
 	var warnings []Warning
 	for _, c := range cfg.Classifications {
+		if c.Name == noChanges {
+			continue
+		}
 		if len(c.Rules) == 0 && !hasPluginAnalyzers(c) && c.BlastRadius == nil && c.Topology == nil {
 			warnings = append(warnings, Warning{
 				Classification: c.Name,

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -420,7 +420,7 @@ func isCatchAllRule(rule RuleConfig) bool {
 
 // warnEmptyClassifications warns when a classification has no rules and no plugin
 // analyzer blocks, meaning it can never match anything. The classification
-// referenced by defaults.no_changes is exempt — CR-0035 routes no-op resources
+// referenced by defaults.no_changes is exempt — CR-0036 routes no-op resources
 // to it via short-circuit, so it does not need rules.
 func warnEmptyClassifications(cfg *Config) []Warning {
 	var noChanges string

--- a/internal/output/formatter.go
+++ b/internal/output/formatter.go
@@ -171,7 +171,7 @@ func (f *Formatter) formatText(result *classify.Result) error {
 					byClassification[decision.Classification], decision)
 			}
 
-			totalNoOp := 0
+			noopByClassification := make(map[string]int)
 			for _, classification := range classificationOrder {
 				decisions := byClassification[classification]
 
@@ -184,7 +184,7 @@ func (f *Formatter) formatText(result *classify.Result) error {
 						active = append(active, d)
 					}
 				}
-				totalNoOp += len(noop)
+				noopByClassification[classification] = len(noop)
 
 				// Skip classifications that contain only no-op resources
 				if len(active) == 0 {
@@ -209,23 +209,23 @@ func (f *Formatter) formatText(result *classify.Result) error {
 				}
 				sb.WriteByte('\n')
 			}
-			if totalNoOp > 0 {
-				fmt.Fprintf(&sb, "(%d no-op resources hidden)\n", totalNoOp)
-			}
+			writeNoOpSummary(&sb, "", classificationOrder, noopByClassification)
 		} else {
 			// Compact output — skip no-op resources
-			noopCount := 0
+			noopByClassification := make(map[string]int)
+			classificationOrder := make([]string, 0)
 			for _, decision := range result.ResourceDecisions {
 				if isNoOpDecision(decision) {
-					noopCount++
+					if _, seen := noopByClassification[decision.Classification]; !seen {
+						classificationOrder = append(classificationOrder, decision.Classification)
+					}
+					noopByClassification[decision.Classification]++
 					continue
 				}
 				fmt.Fprintf(&sb, "  [%s] %s\n",
 					decision.Classification, decision.Address)
 			}
-			if noopCount > 0 {
-				fmt.Fprintf(&sb, "  (%d no-op resources hidden)\n", noopCount)
-			}
+			writeNoOpSummary(&sb, "  ", classificationOrder, noopByClassification)
 		}
 	}
 
@@ -241,6 +241,31 @@ func isNoOpDecision(d classify.ResourceDecision) bool {
 		}
 	}
 	return true
+}
+
+// writeNoOpSummary prints the "N no-op resources hidden" line with a per-classification
+// breakdown, so a reader can see what a config's ignore_attributes filtered out instead
+// of having to trust an opaque flat count.
+func writeNoOpSummary(sb *strings.Builder, indent string, order []string, counts map[string]int) {
+	total := 0
+	for _, c := range order {
+		total += counts[c]
+	}
+	if total == 0 {
+		return
+	}
+
+	var parts []string
+	for _, c := range order {
+		if n := counts[c]; n > 0 {
+			parts = append(parts, fmt.Sprintf("%s: %d", c, n))
+		}
+	}
+	if len(parts) > 1 {
+		fmt.Fprintf(sb, "%s(%d no-op resources hidden — %s)\n", indent, total, strings.Join(parts, ", "))
+	} else {
+		fmt.Fprintf(sb, "%s(%d no-op resources hidden)\n", indent, total)
+	}
 }
 
 func (f *Formatter) formatGitHub(result *classify.Result) error {

--- a/internal/output/formatter.go
+++ b/internal/output/formatter.go
@@ -159,11 +159,29 @@ func (f *Formatter) formatText(result *classify.Result) error {
 		fmt.Fprintf(&sb, "Resources: %d\n", activeCount)
 		sb.WriteByte('\n')
 
+		// Partition decisions into three buckets: active (real changes),
+		// downgraded (no-op via ignore_attributes — OriginalActions set), and
+		// native no-ops (no-op from Terraform itself).
+		var downgraded, nativeNoOp []classify.ResourceDecision
+		for _, d := range result.ResourceDecisions {
+			if !isNoOpDecision(d) {
+				continue
+			}
+			if len(d.OriginalActions) > 0 {
+				downgraded = append(downgraded, d)
+			} else {
+				nativeNoOp = append(nativeNoOp, d)
+			}
+		}
+
 		if f.verbose {
-			// Group by classification
+			// Group active decisions by classification
 			byClassification := make(map[string][]classify.ResourceDecision)
 			classificationOrder := make([]string, 0)
 			for _, decision := range result.ResourceDecisions {
+				if isNoOpDecision(decision) {
+					continue
+				}
 				if _, seen := byClassification[decision.Classification]; !seen {
 					classificationOrder = append(classificationOrder, decision.Classification)
 				}
@@ -171,61 +189,54 @@ func (f *Formatter) formatText(result *classify.Result) error {
 					byClassification[decision.Classification], decision)
 			}
 
-			noopByClassification := make(map[string]int)
 			for _, classification := range classificationOrder {
-				decisions := byClassification[classification]
-
-				// Separate active changes from no-ops
-				var active, noop []classify.ResourceDecision
-				for _, d := range decisions {
-					if isNoOpDecision(d) {
-						noop = append(noop, d)
-					} else {
-						active = append(active, d)
-					}
-				}
-				noopByClassification[classification] = len(noop)
-
-				// Skip classifications that contain only no-op resources
-				if len(active) == 0 {
-					continue
-				}
-
+				active := byClassification[classification]
 				fmt.Fprintf(&sb, "[%s] (%d resources)\n", classification, len(active))
-				// Show classification description if available (from first decision)
 				if active[0].ClassificationDescription != "" {
 					fmt.Fprintf(&sb, "  %s\n", active[0].ClassificationDescription)
 				}
 				for _, decision := range active {
 					fmt.Fprintf(&sb, "  - %s (%s) %v\n",
 						decision.Address, decision.ResourceType, decision.Actions)
-					if len(decision.OriginalActions) > 0 {
-						fmt.Fprintf(&sb, "    Originally: %v (downgraded by ignore_attributes: %s)\n",
-							decision.OriginalActions, strings.Join(decision.IgnoredAttributes, ", "))
-					}
 					for _, rule := range decision.MatchedRules {
 						fmt.Fprintf(&sb, "    Rule: %s\n", rule)
 					}
 				}
 				sb.WriteByte('\n')
 			}
-			writeNoOpSummary(&sb, "", classificationOrder, noopByClassification)
+
+			// Always show downgraded resources in full, so users can diagnose
+			// which attributes the ignore_attributes filter absorbed and which
+			// synthetic rule each resource matched. This is the primary
+			// diagnostic surface for cosmetic-filter behavior.
+			if len(downgraded) > 0 {
+				fmt.Fprintf(&sb, "Downgraded to no-op by ignore_attributes (%d):\n", len(downgraded))
+				for _, d := range downgraded {
+					fmt.Fprintf(&sb, "  - %s (%s)\n", d.Address, d.ResourceType)
+					fmt.Fprintf(&sb, "    Originally: %v  (ignored: %s)\n",
+						d.OriginalActions, strings.Join(d.IgnoredAttributes, ", "))
+					for _, rule := range d.MatchedRules {
+						fmt.Fprintf(&sb, "    Rule: %s\n", rule)
+					}
+				}
+				sb.WriteByte('\n')
+			}
+
+			if len(nativeNoOp) > 0 {
+				fmt.Fprintf(&sb, "(%d native no-op resources hidden)\n", len(nativeNoOp))
+			}
 		} else {
-			// Compact output — skip no-op resources
-			noopByClassification := make(map[string]int)
-			classificationOrder := make([]string, 0)
+			// Compact output — one line per active resource, then a count split
+			// between downgraded and native no-ops so CI logs still surface the
+			// downgrade footprint without being flooded with per-resource detail.
 			for _, decision := range result.ResourceDecisions {
 				if isNoOpDecision(decision) {
-					if _, seen := noopByClassification[decision.Classification]; !seen {
-						classificationOrder = append(classificationOrder, decision.Classification)
-					}
-					noopByClassification[decision.Classification]++
 					continue
 				}
 				fmt.Fprintf(&sb, "  [%s] %s\n",
 					decision.Classification, decision.Address)
 			}
-			writeNoOpSummary(&sb, "  ", classificationOrder, noopByClassification)
+			writeHiddenNoOpCount(&sb, "  ", len(downgraded), len(nativeNoOp))
 		}
 	}
 
@@ -243,28 +254,24 @@ func isNoOpDecision(d classify.ResourceDecision) bool {
 	return true
 }
 
-// writeNoOpSummary prints the "N no-op resources hidden" line with a per-classification
-// breakdown, so a reader can see what a config's ignore_attributes filtered out instead
-// of having to trust an opaque flat count.
-func writeNoOpSummary(sb *strings.Builder, indent string, order []string, counts map[string]int) {
-	total := 0
-	for _, c := range order {
-		total += counts[c]
-	}
+// writeHiddenNoOpCount prints the "N no-op resources hidden" line for compact
+// output, split between ignore_attributes downgrades and Terraform-native
+// no-ops so a reader can see whether the filter is doing the work.
+func writeHiddenNoOpCount(sb *strings.Builder, indent string, downgraded, native int) {
+	total := downgraded + native
 	if total == 0 {
 		return
 	}
 
-	var parts []string
-	for _, c := range order {
-		if n := counts[c]; n > 0 {
-			parts = append(parts, fmt.Sprintf("%s: %d", c, n))
-		}
-	}
-	if len(parts) > 1 {
-		fmt.Fprintf(sb, "%s(%d no-op resources hidden — %s)\n", indent, total, strings.Join(parts, ", "))
-	} else {
-		fmt.Fprintf(sb, "%s(%d no-op resources hidden)\n", indent, total)
+	switch {
+	case downgraded > 0 && native > 0:
+		fmt.Fprintf(sb, "%s(%d no-op resources hidden — %d downgraded by ignore_attributes, %d native; rerun with -v for detail)\n",
+			indent, total, downgraded, native)
+	case downgraded > 0:
+		fmt.Fprintf(sb, "%s(%d no-op resources hidden — downgraded by ignore_attributes; rerun with -v for detail)\n",
+			indent, downgraded)
+	default:
+		fmt.Fprintf(sb, "%s(%d no-op resources hidden — native)\n", indent, native)
 	}
 }
 

--- a/internal/output/formatter_test.go
+++ b/internal/output/formatter_test.go
@@ -201,6 +201,55 @@ func TestFormatText_NoChangesWithDowngradedNonVerbose(t *testing.T) {
 	}
 }
 
+// Mixed real + no-op resources: the "hidden" line must break the no-op count
+// down by classification so the reader can see what ignore_attributes filtered
+// out. Without this, an output showing `Classification: minor` next to an opaque
+// "(95 no-op resources hidden)" forces the reader to guess what matched.
+func TestFormatText_MixedNoOpBreakdownVerbose(t *testing.T) {
+	result := &classify.Result{
+		Overall:         "minor",
+		OverallExitCode: 0,
+		NoChanges:       false,
+		ResourceDecisions: []classify.ResourceDecision{
+			{
+				Address:        "data.azapi_resource_action.keys[0]",
+				ResourceType:   "azapi_resource_action",
+				Actions:        []string{"read"},
+				Classification: "minor",
+				MatchedRules:   []string{"Data source reads"},
+			},
+			{
+				Address:           "azurerm_key_vault_key.cmk",
+				ResourceType:      "azurerm_key_vault_key",
+				Actions:           []string{"no-op"},
+				OriginalActions:   []string{"update"},
+				IgnoredAttributes: []string{"tags.tf-module-l2"},
+				Classification:    "major",
+			},
+			{
+				Address:           "azurerm_resource_group.rg",
+				ResourceType:      "azurerm_resource_group",
+				Actions:           []string{"no-op"},
+				OriginalActions:   []string{"update"},
+				IgnoredAttributes: []string{"tags.tf-module-l2"},
+				Classification:    "minor",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	formatter := NewFormatter(&buf, FormatText, true)
+	if err := formatter.Format(result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+
+	if !strings.Contains(output, "(2 no-op resources hidden — minor: 1, major: 1)") {
+		t.Errorf("expected breakdown of hidden no-op resources by classification, got:\n%s", output)
+	}
+}
+
 func TestFormatGitHub(t *testing.T) {
 	result := &classify.Result{
 		Overall:         "critical",

--- a/internal/output/formatter_test.go
+++ b/internal/output/formatter_test.go
@@ -201,11 +201,10 @@ func TestFormatText_NoChangesWithDowngradedNonVerbose(t *testing.T) {
 	}
 }
 
-// Mixed real + no-op resources: the "hidden" line must break the no-op count
-// down by classification so the reader can see what ignore_attributes filtered
-// out. Without this, an output showing `Classification: minor` next to an opaque
-// "(95 no-op resources hidden)" forces the reader to guess what matched.
-func TestFormatText_MixedNoOpBreakdownVerbose(t *testing.T) {
+// Verbose output must show downgraded resources in full — address, original
+// action, ignored attribute paths, and synthetic matched rule — so users can
+// diagnose which rule matched and why without running `explain`.
+func TestFormatText_DowngradedSectionVerbose(t *testing.T) {
 	result := &classify.Result{
 		Overall:         "minor",
 		OverallExitCode: 0,
@@ -224,15 +223,15 @@ func TestFormatText_MixedNoOpBreakdownVerbose(t *testing.T) {
 				Actions:           []string{"no-op"},
 				OriginalActions:   []string{"update"},
 				IgnoredAttributes: []string{"tags.tf-module-l2"},
-				Classification:    "major",
+				Classification:    "auto",
+				MatchedRules:      []string{"no-op (downgraded by ignore_attributes: tags.tf-module-l2)"},
 			},
 			{
-				Address:           "azurerm_resource_group.rg",
-				ResourceType:      "azurerm_resource_group",
-				Actions:           []string{"no-op"},
-				OriginalActions:   []string{"update"},
-				IgnoredAttributes: []string{"tags.tf-module-l2"},
-				Classification:    "minor",
+				Address:        "azurerm_storage_account.refreshed",
+				ResourceType:   "azurerm_storage_account",
+				Actions:        []string{"no-op"},
+				Classification: "auto",
+				MatchedRules:   []string{"no-op (no change)"},
 			},
 		},
 	}
@@ -245,8 +244,119 @@ func TestFormatText_MixedNoOpBreakdownVerbose(t *testing.T) {
 
 	output := buf.String()
 
-	if !strings.Contains(output, "(2 no-op resources hidden — minor: 1, major: 1)") {
-		t.Errorf("expected breakdown of hidden no-op resources by classification, got:\n%s", output)
+	if !strings.Contains(output, "Downgraded to no-op by ignore_attributes (1):") {
+		t.Errorf("expected Downgraded section header, got:\n%s", output)
+	}
+	if !strings.Contains(output, "azurerm_key_vault_key.cmk") {
+		t.Errorf("expected downgraded resource address in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "ignored: tags.tf-module-l2") {
+		t.Errorf("expected ignored attribute paths in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "Rule: no-op (downgraded by ignore_attributes: tags.tf-module-l2)") {
+		t.Errorf("expected synthetic matched rule in output, got:\n%s", output)
+	}
+	// Native no-op should be summarized as a count, not listed per-resource.
+	if !strings.Contains(output, "(1 native no-op resources hidden)") {
+		t.Errorf("expected native no-op count line, got:\n%s", output)
+	}
+	if strings.Contains(output, "azurerm_storage_account.refreshed") {
+		t.Errorf("native no-op resource should not be listed per-resource in verbose output, got:\n%s", output)
+	}
+}
+
+// When only downgrades are hidden, the compact line must still flag the
+// ignore_attributes filter and direct the user to --verbose.
+func TestFormatText_HiddenCountOnlyDowngradedCompact(t *testing.T) {
+	result := &classify.Result{
+		Overall:         "minor",
+		OverallExitCode: 0,
+		NoChanges:       false,
+		ResourceDecisions: []classify.ResourceDecision{
+			{Address: "data.r.x", Actions: []string{"read"}, Classification: "minor"},
+			{Address: "azurerm_key_vault_key.cmk", Actions: []string{"no-op"},
+				OriginalActions: []string{"update"}, Classification: "auto"},
+		},
+	}
+	var buf bytes.Buffer
+	if err := NewFormatter(&buf, FormatText, false).Format(result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "(1 no-op resources hidden — downgraded by ignore_attributes; rerun with -v for detail)") {
+		t.Errorf("expected downgrade-only compact line with rerun hint, got:\n%s", output)
+	}
+}
+
+// When only native no-ops are hidden, the compact line must not imply
+// ignore_attributes is doing the work and must not direct users to -v
+// (there's nothing to diagnose).
+func TestFormatText_HiddenCountOnlyNativeCompact(t *testing.T) {
+	result := &classify.Result{
+		Overall:         "minor",
+		OverallExitCode: 0,
+		NoChanges:       false,
+		ResourceDecisions: []classify.ResourceDecision{
+			{Address: "data.r.x", Actions: []string{"read"}, Classification: "minor"},
+			{Address: "azurerm_storage_account.refreshed", Actions: []string{"no-op"}, Classification: "auto"},
+		},
+	}
+	var buf bytes.Buffer
+	if err := NewFormatter(&buf, FormatText, false).Format(result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "(1 no-op resources hidden — native)") {
+		t.Errorf("expected native-only compact line, got:\n%s", output)
+	}
+	if strings.Contains(output, "ignore_attributes") {
+		t.Errorf("native-only line must not mention ignore_attributes, got:\n%s", output)
+	}
+	if strings.Contains(output, "rerun with -v") {
+		t.Errorf("native-only line must not suggest rerunning verbose, got:\n%s", output)
+	}
+}
+
+// Compact output must split the hidden count between ignore_attributes
+// downgrades and native no-ops, so CI logs surface the downgrade footprint
+// without being flooded with per-resource detail.
+func TestFormatText_HiddenCountSplitCompact(t *testing.T) {
+	result := &classify.Result{
+		Overall:         "minor",
+		OverallExitCode: 0,
+		NoChanges:       false,
+		ResourceDecisions: []classify.ResourceDecision{
+			{
+				Address:        "data.azapi_resource_action.keys[0]",
+				Actions:        []string{"read"},
+				Classification: "minor",
+			},
+			{
+				Address:         "azurerm_key_vault_key.cmk",
+				Actions:         []string{"no-op"},
+				OriginalActions: []string{"update"},
+				Classification:  "auto",
+			},
+			{
+				Address:        "azurerm_storage_account.refreshed",
+				Actions:        []string{"no-op"},
+				Classification: "auto",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	formatter := NewFormatter(&buf, FormatText, false)
+	if err := formatter.Format(result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "1 downgraded by ignore_attributes, 1 native") {
+		t.Errorf("expected compact count to split downgraded vs native, got:\n%s", output)
+	}
+	if !strings.Contains(output, "rerun with -v for detail") {
+		t.Errorf("expected hint to rerun with -v, got:\n%s", output)
 	}
 }
 

--- a/testdata/e2e/blast-radius/.tfclassify.hcl
+++ b/testdata/e2e/blast-radius/.tfclassify.hcl
@@ -19,11 +19,6 @@ classification "standard" {
 classification "auto" {
   description = "Auto-approved"
   sarif_level = "none"
-
-  rule {
-    resource = ["*"]
-    actions  = ["no-op"]
-  }
 }
 
 precedence = ["critical", "standard", "auto"]

--- a/testdata/e2e/cis-azure-foundations/.tfclassify.hcl
+++ b/testdata/e2e/cis-azure-foundations/.tfclassify.hcl
@@ -50,11 +50,6 @@ classification "standard" {
 
 classification "auto" {
   description = "No approval needed"
-
-  rule {
-    resource = ["*"]
-    actions  = ["no-op"]
-  }
 }
 
 # Precedence maps to exit codes:

--- a/testdata/e2e/combined-role-aggregation/.tfclassify.hcl
+++ b/testdata/e2e/combined-role-aggregation/.tfclassify.hcl
@@ -38,11 +38,6 @@ classification "standard" {
 
 classification "auto" {
   description = "Auto-approved"
-
-  rule {
-    resource = ["*"]
-    actions  = ["no-op"]
-  }
 }
 
 precedence = ["critical", "standard", "auto"]

--- a/testdata/e2e/control-plane-patterns/.tfclassify.hcl
+++ b/testdata/e2e/control-plane-patterns/.tfclassify.hcl
@@ -38,11 +38,6 @@ classification "standard" {
 
 classification "auto" {
   description = "Auto-approved"
-
-  rule {
-    resource = ["*"]
-    actions  = ["no-op"]
-  }
 }
 
 precedence = ["critical", "standard", "auto"]

--- a/testdata/e2e/custom-role-cross-reference/.tfclassify.hcl
+++ b/testdata/e2e/custom-role-cross-reference/.tfclassify.hcl
@@ -32,11 +32,6 @@ classification "standard" {
 
 classification "auto" {
   description = "Auto-approved"
-
-  rule {
-    resource = ["*"]
-    actions  = ["no-op"]
-  }
 }
 
 precedence = ["critical", "standard", "auto"]

--- a/testdata/e2e/data-plane-detection/.tfclassify.hcl
+++ b/testdata/e2e/data-plane-detection/.tfclassify.hcl
@@ -40,11 +40,6 @@ classification "standard" {
 
 classification "auto" {
   description = "Auto-approved"
-
-  rule {
-    resource = ["*"]
-    actions  = ["no-op"]
-  }
 }
 
 precedence = ["critical", "standard", "auto"]

--- a/testdata/e2e/evidence-signing/.tfclassify.hcl
+++ b/testdata/e2e/evidence-signing/.tfclassify.hcl
@@ -8,11 +8,6 @@ classification "standard" {
 
 classification "auto" {
   description = "Auto-approved"
-
-  rule {
-    resource = ["*"]
-    actions  = ["no-op"]
-  }
 }
 
 precedence = ["standard", "auto"]

--- a/testdata/e2e/module-scoped-rules/.tfclassify.hcl
+++ b/testdata/e2e/module-scoped-rules/.tfclassify.hcl
@@ -22,11 +22,6 @@ classification "standard" {
 
 classification "auto" {
   description = "Auto-approved"
-
-  rule {
-    resource = ["*"]
-    actions  = ["no-op"]
-  }
 }
 
 precedence = ["critical", "standard", "auto"]

--- a/testdata/e2e/modules-plugin/.tfclassify.hcl
+++ b/testdata/e2e/modules-plugin/.tfclassify.hcl
@@ -29,11 +29,6 @@ classification "standard" {
 
 classification "auto" {
   description = "Auto-approved"
-
-  rule {
-    resource = ["*"]
-    actions  = ["no-op"]
-  }
 }
 
 precedence = ["critical", "standard", "auto"]

--- a/testdata/e2e/modules-pluginless/.tfclassify.hcl
+++ b/testdata/e2e/modules-pluginless/.tfclassify.hcl
@@ -17,11 +17,6 @@ classification "standard" {
 
 classification "auto" {
   description = "Auto-approved"
-
-  rule {
-    resource = ["*"]
-    actions  = ["no-op"]
-  }
 }
 
 precedence = ["critical", "standard", "auto"]

--- a/testdata/e2e/role-assignment-privileged/.tfclassify.hcl
+++ b/testdata/e2e/role-assignment-privileged/.tfclassify.hcl
@@ -31,11 +31,6 @@ classification "standard" {
 
 classification "auto" {
   description = "Auto-approved"
-
-  rule {
-    resource = ["*"]
-    actions  = ["no-op"]
-  }
 }
 
 precedence = ["critical", "standard", "auto"]

--- a/testdata/e2e/role-assignment-reader/.tfclassify.hcl
+++ b/testdata/e2e/role-assignment-reader/.tfclassify.hcl
@@ -17,11 +17,6 @@ classification "standard" {
 
 classification "auto" {
   description = "Auto-approved"
-
-  rule {
-    resource = ["*"]
-    actions  = ["no-op"]
-  }
 }
 
 precedence = ["critical", "standard", "auto"]

--- a/testdata/e2e/role-escalation-threshold/.tfclassify.hcl
+++ b/testdata/e2e/role-escalation-threshold/.tfclassify.hcl
@@ -40,11 +40,6 @@ classification "standard" {
 
 classification "auto" {
   description = "Auto-approved"
-
-  rule {
-    resource = ["*"]
-    actions  = ["no-op"]
-  }
 }
 
 precedence = ["critical", "standard", "auto"]

--- a/testdata/e2e/role-exclusion/.tfclassify.hcl
+++ b/testdata/e2e/role-exclusion/.tfclassify.hcl
@@ -37,11 +37,6 @@ classification "standard" {
 
 classification "auto" {
   description = "Auto-approved"
-
-  rule {
-    resource = ["*"]
-    actions  = ["no-op"]
-  }
 }
 
 precedence = ["critical", "standard", "auto"]

--- a/testdata/e2e/route-table/.tfclassify.hcl
+++ b/testdata/e2e/route-table/.tfclassify.hcl
@@ -17,11 +17,6 @@ classification "standard" {
 
 classification "auto" {
   description = "Auto-approved"
-
-  rule {
-    resource = ["*"]
-    actions  = ["no-op"]
-  }
 }
 
 precedence = ["critical", "standard", "auto"]

--- a/testdata/e2e/topology/.tfclassify.hcl
+++ b/testdata/e2e/topology/.tfclassify.hcl
@@ -21,11 +21,6 @@ classification "standard" {
 
 classification "auto" {
   description = "Auto-approved"
-
-  rule {
-    resource = ["*"]
-    actions  = ["no-op"]
-  }
 }
 
 precedence = ["critical", "standard", "auto"]


### PR DESCRIPTION
# CR-0036: Skip classification rule evaluation for no-op resources

## What

No-op resource changes (`actions = ["no-op"]`) now short-circuit in the classifier: they bypass rule iteration, inherit `defaults.no_changes`, and get a synthetic matched-rule description. Downgraded resources remain diagnosable in the output — verbose mode lists them in full; compact mode splits the hidden count between `ignore_attributes` downgrades and native no-ops.

## Why

Since **CR-0034** (`ignore_attributes`), tag-only updates get downgraded to `["no-op"]` — routinely. The classifier still evaluated rules over them, so any rule without an explicit `not_actions = ["no-op"]` silently matched and elevated `Overall`. The text renderer hid the no-op resources from view, so the output looked like this:

```
Classification: major
Resources: 1
[minor] (1 resources)
  - data.azapi_resource_action.account_keys[0] (azapi_resource_action) [read]
(95 no-op resources hidden)
```

`major` — with zero visible major resources. The output was lying.

Every one of the 16 e2e configs in this repo carried the same workaround rule to absorb no-ops at the lowest precedence — strong evidence the pattern was boilerplate the mental model imposed, not genuine configuration.

## Value

- **Honest output**: `Classification: minor` now means "the highest real change is minor". No mental translation through the filter.
- **Zero boilerplate**: rule authors no longer need `not_actions = ["no-op"]` on every rule, and no longer need a catch-all `actions = ["no-op"]` rule.
- **Diagnosable**: verbose output shows every downgraded resource with its original action, the attribute paths the filter absorbed, and the synthetic matched rule — no need to drop to `tfclassify explain` for the common case.
- **CI-friendly**: compact output surfaces the downgrade footprint as a single count line so logs stay tight, with a hint pointing to `-v` when detail is wanted.
- **Backward compatible**: existing configs with the workaround rule still parse and run. The rule just becomes dead code.

## Usage

Before (required workaround):

```hcl
classification "major" {
  rule {
    resource    = ["azurerm_key_vault_key"]
    not_actions = ["no-op"]   # boilerplate to dodge cosmetic matches
  }
}

classification "auto" {
  rule {
    resource = ["*"]
    actions  = ["no-op"]   # catch-all to absorb no-ops
  }
}
```

After:

```hcl
classification "major" {
  rule {
    resource = ["azurerm_key_vault_key"]
  }
}

classification "auto" {
  description = "No approval needed"
  # no rules — no-op resources short-circuit here via defaults.no_changes
}

defaults {
  no_changes        = "auto"
  ignore_attributes = ["tags", "tags_all"]
}
```

Verbose output against a plan with one real data-source read, two tag-only downgrades, and one native no-op:

```
Classification: minor
  Plumbing
Exit code: 1
Resources: 1

[minor] (1 resources)
  Plumbing
  - module.aiwz.data.azapi_resource_action.account_keys[0] (azapi_resource_action) [read]
    Rule: Data reads

Downgraded to no-op by ignore_attributes (2):
  - module.aiwz.azurerm_key_vault_key.cmk (azurerm_key_vault_key)
    Originally: [update]  (ignored: tags.tf-module-l2)
    Rule: no-op (downgraded by ignore_attributes: tags.tf-module-l2)
  - module.aiwz.azurerm_resource_group.ai_app (azurerm_resource_group)
    Originally: [update]  (ignored: tags.tf-module-l2)
    Rule: no-op (downgraded by ignore_attributes: tags.tf-module-l2)

(1 native no-op resources hidden)
```

Compact output (same plan):

```
Classification: minor
Exit code: 1
Resources: 1

  [minor] module.aiwz.data.azapi_resource_action.account_keys[0]
  (3 no-op resources hidden — 2 downgraded by ignore_attributes, 1 native; rerun with -v for detail)
```

## Scope

- `classifyResource` and `explainResource` short-circuit on `isNoOp(change.Actions)`.
- `Classify` and `AddPluginDecisions` continue to exclude no-op decisions from `Overall` (defense in depth for plugin decisions).
- Verbose text output: dedicated "Downgraded to no-op by ignore_attributes" section per resource, plus a native-no-op count line.
- Compact text output: split count between downgrades and native no-ops, with a rerun-verbose hint when downgrades exist.
- Validator exempts the classification referenced by `defaults.no_changes` from the "has no rules" warning.
- Workaround rule removed from all 16 e2e configs and the full-reference example; `newTestConfig` updated.
- CR-0034 gets a follow-up note pointing at CR-0036.

## Test Coverage

Classifier (`internal/classify/classifier_test.go`):

- `TestClassifyResource_NoOpShortCircuit` — downgraded no-op inherits `defaults.no_changes`, synthetic rule references `ignore_attributes` and the ignored path, and does not reference the major rule that would otherwise match the type.
- `TestClassifyResource_NativeNoOp` — native no-op gets `"no-op (no change)"` synthetic rule.
- `TestExplainClassify_NoOpSingleTraceEntry` — explain emits exactly one synthetic trace entry instead of iterating rules.
- `TestClassify_NoOpDoesNotElevateOverall` — no-op decisions do not raise `Overall` above the highest real classification.
- `TestClassify_AllNoOpReportsNoChanges` and `TestClassify_MixedNoOpAndRealNotNoChanges` continue to pass against the updated `newTestConfig` (auto classification has no rules).

Text output (`internal/output/formatter_test.go`):

- `TestFormatText_DowngradedSectionVerbose` — verbose output renders the "Downgraded to no-op by ignore_attributes (N):" header with per-resource address, type, original actions, ignored paths, and synthetic rule; native no-ops collapse into a count line and are not listed per-resource.
- `TestFormatText_HiddenCountSplitCompact` — compact line splits "X downgraded by ignore_attributes, Y native" with the rerun hint.
- `TestFormatText_HiddenCountOnlyDowngradedCompact` — only downgrades → "downgraded by ignore_attributes; rerun with -v".
- `TestFormatText_HiddenCountOnlyNativeCompact` — only native no-ops → "native", no `ignore_attributes` mention, no rerun hint.
- `TestFormatText_NoChangesWithDowngradedVerbose` and `TestFormatText_NoChangesWithDowngradedNonVerbose` — pre-existing all-no-op cases continue to pass.

End-to-end:

- `make ci` green (build, test, vet, golangci-lint, govulncheck).
- `bash testdata/e2e/run.sh --build --fixtures` — 16/16 pass after workaround removal.

Full spec: `docs/cr/CR-0036-skip-noop-rule-evaluation.md`.