### PR TITLE
fix: warn on module glob overlap and skip fixture-only verify scenarios

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,10 @@ jobs:
       - name: Discover e2e scenarios
         id: discover
         run: |
-          matrix=$(jq -cn '[ inputs | {
+          # Scenarios marked fixture_only have no main.tf — they exercise the
+          # classifier against committed plan JSON only. Skip them in the
+          # live e2e matrix; the e2e-fixtures job above still classifies them.
+          matrix=$(jq -cn '[ inputs | select((.fixture_only // false) | not) | {
             "use-case": input_filename | split("/")[-2],
             "plan-only": (.plan_only // false),
             "evidence": (.evidence // false)

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -66,7 +66,10 @@ jobs:
       - name: Discover e2e scenarios
         id: discover
         run: |
-          matrix=$(jq -cn '[ inputs | {
+          # Scenarios marked fixture_only have no main.tf — they exercise the
+          # classifier against committed plan JSON only and cannot be replanned
+          # against live Azure. Skip them in the verify matrix.
+          matrix=$(jq -cn '[ inputs | select((.fixture_only // false) | not) | {
             "use-case": input_filename | split("/")[-2],
             "plan-only": (.plan_only // false),
             "evidence": (.evidence // false)

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -413,6 +413,7 @@ func ValidateWarnings(cfg *Config) []Warning {
 	warnings = append(warnings, warnEmptyClassifications(cfg)...)
 	warnings = append(warnings, warnMissingPluginBinaries(cfg)...)
 	warnings = append(warnings, warnRedundantNotResource(cfg)...)
+	warnings = append(warnings, warnModuleGlobOverlap(cfg)...)
 	return warnings
 }
 
@@ -587,4 +588,214 @@ func warnRedundantNotResource(cfg *Config) []Warning {
 	}
 
 	return warnings
+}
+
+// warnModuleGlobOverlap warns when two rules in different classifications have
+// overlapping module globs. The author likely meant the patterns to be
+// disjoint; without that, the rule whose classification appears earlier in
+// `precedence` silently wins for the overlapping addresses.
+//
+// The classic case is a prefix-greedy `*` that consumes more than the author
+// intended — e.g. `**.foo*` matches both `module.foo["k"]` and
+// `module.foo_bar["k"]`. If `**.foo_bar*` is a separate rule in another
+// classification, both rules match `module.foo_bar["k"]` and the higher-
+// precedence one wins.
+func warnModuleGlobOverlap(cfg *Config) []Warning {
+	type rulePos struct {
+		classification string
+		ruleIdx        int
+		ruleDesc       string
+		pattern        string
+	}
+
+	// Collect every (classification, rule, pattern) triple, skipping rules
+	// without module patterns. Skip any pattern that is just "*" or "**"
+	// since those are already covered by warnUnreachableRules.
+	var triples []rulePos
+	for _, c := range cfg.Classifications {
+		for i, rule := range c.Rules {
+			for _, p := range rule.Module {
+				if isTrivialModulePattern(p) {
+					continue
+				}
+				triples = append(triples, rulePos{
+					classification: c.Name,
+					ruleIdx:        i + 1,
+					ruleDesc:       rule.Description,
+					pattern:        p,
+				})
+			}
+		}
+	}
+
+	// Walk every cross-classification pattern pair and emit a warning when
+	// they overlap. Use a sorted (a,b) key per emitted pair so the same
+	// overlap is not reported twice.
+	emitted := make(map[string]bool)
+	var warnings []Warning
+	for i := 0; i < len(triples); i++ {
+		for j := i + 1; j < len(triples); j++ {
+			a, b := triples[i], triples[j]
+			if a.classification == b.classification {
+				continue
+			}
+			sample, ok := patternsOverlap(a.pattern, b.pattern)
+			if !ok {
+				continue
+			}
+			key := overlapKey(a.classification, a.ruleIdx, a.pattern, b.classification, b.ruleIdx, b.pattern)
+			if emitted[key] {
+				continue
+			}
+			emitted[key] = true
+			warnings = append(warnings, Warning{
+				Message: fmt.Sprintf(
+					"module glob overlap: classification %q rule %d (%s) and classification %q rule %d (%s) both match %q; the classification listed first in precedence will win",
+					a.classification, a.ruleIdx, describePattern(a),
+					b.classification, b.ruleIdx, describePattern(b),
+					sample,
+				),
+			})
+		}
+	}
+	return warnings
+}
+
+// describePattern returns either the rule's user-provided description (if any)
+// or the raw module pattern, used to help the author find the overlap source.
+func describePattern(r struct {
+	classification string
+	ruleIdx        int
+	ruleDesc       string
+	pattern        string
+}) string {
+	if r.ruleDesc != "" {
+		return fmt.Sprintf("%q, module=%q", r.ruleDesc, r.pattern)
+	}
+	return fmt.Sprintf("module=%q", r.pattern)
+}
+
+// overlapKey returns a stable key for an unordered pair of (classification,
+// rule, pattern) tuples so the same overlap warning is not emitted twice.
+func overlapKey(ac string, ai int, ap, bc string, bi int, bp string) string {
+	left := fmt.Sprintf("%s|%d|%s", ac, ai, ap)
+	right := fmt.Sprintf("%s|%d|%s", bc, bi, bp)
+	if left < right {
+		return left + "<>" + right
+	}
+	return right + "<>" + left
+}
+
+// isTrivialModulePattern reports whether a module pattern is a catch-all
+// (matches every address). Trivial patterns are excluded from overlap
+// detection since they overlap with everything by definition; the
+// unreachable-rule warning covers that case.
+func isTrivialModulePattern(p string) bool {
+	switch p {
+	case "*", "**", "**.*", "*.**":
+		return true
+	}
+	return false
+}
+
+// patternsOverlap reports whether two module globs share at least one
+// matching address. When they do, it also returns a sample address that
+// matches both, suitable for surfacing in a warning. Both patterns are
+// compiled with '.' as the path separator (matching how the matcher
+// compiles module patterns).
+//
+// The check is approximate: it concretizes each pattern by substituting
+// wildcards with placeholder characters and tests whether the other
+// pattern matches that concrete form. If either direction matches,
+// overlap is confirmed. Misses are possible for exotic patterns
+// (e.g. character classes that exclude the placeholder) but the common
+// shapes used in real configs (`**.foo`, `**.foo*`, `**.foo.*`) are
+// caught reliably.
+func patternsOverlap(patternA, patternB string) (string, bool) {
+	gA, err := glob.Compile(patternA, '.')
+	if err != nil {
+		return "", false
+	}
+	gB, err := glob.Compile(patternB, '.')
+	if err != nil {
+		return "", false
+	}
+
+	candA := concretizeModulePattern(patternA)
+	if candA != "" && gB.Match(candA) {
+		return candA, true
+	}
+	candB := concretizeModulePattern(patternB)
+	if candB != "" && gA.Match(candB) {
+		return candB, true
+	}
+	return "", false
+}
+
+// concretizeModulePattern replaces glob wildcards in a module pattern with
+// literal placeholder characters, producing a sample address that the
+// pattern would match. Used to probe whether another pattern also matches
+// that address (overlap detection). Honors backslash escapes and skips
+// over character classes / brace alternations.
+func concretizeModulePattern(pattern string) string {
+	const placeholder = "x"
+	var b strings.Builder
+	for i := 0; i < len(pattern); {
+		c := pattern[i]
+		switch {
+		case c == '\\' && i+1 < len(pattern):
+			// Escaped char — emit the next byte as a literal.
+			b.WriteByte(pattern[i+1])
+			i += 2
+		case c == '*':
+			// `*` and `**` both collapse to a single placeholder char so the
+			// resulting string contains no separator characters from the wildcard
+			// itself. The rest of the pattern provides the structure.
+			b.WriteString(placeholder)
+			if i+1 < len(pattern) && pattern[i+1] == '*' {
+				i += 2
+			} else {
+				i++
+			}
+		case c == '?':
+			b.WriteString(placeholder)
+			i++
+		case c == '[':
+			// Character class: emit a placeholder and skip past the matching `]`.
+			j := i + 1
+			for j < len(pattern) && pattern[j] != ']' {
+				if pattern[j] == '\\' && j+1 < len(pattern) {
+					j += 2
+				} else {
+					j++
+				}
+			}
+			b.WriteString(placeholder)
+			if j < len(pattern) {
+				i = j + 1
+			} else {
+				i = len(pattern)
+			}
+		case c == '{':
+			// Brace alternation: emit a placeholder and skip past the matching `}`.
+			j := i + 1
+			for j < len(pattern) && pattern[j] != '}' {
+				if pattern[j] == '\\' && j+1 < len(pattern) {
+					j += 2
+				} else {
+					j++
+				}
+			}
+			b.WriteString(placeholder)
+			if j < len(pattern) {
+				i = j + 1
+			} else {
+				i = len(pattern)
+			}
+		default:
+			b.WriteByte(c)
+			i++
+		}
+	}
+	return b.String()
 }

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -739,3 +739,181 @@ func TestValidateWarnings_EmptyClassification_WithPlugin(t *testing.T) {
 		}
 	}
 }
+
+// TestValidateWarnings_ModuleGlobOverlap_PrefixCollision reproduces the
+// audit finding: `**.cognitive_account_foundry*` matches both
+// `module.cognitive_account_foundry["k"]` AND
+// `module.cognitive_account_foundry_kv_connection["k"]` because gobwas/glob
+// `*` greedily consumes the trailing chars after the literal prefix. When a
+// separate rule in another classification targets the connection module
+// specifically, both rules match and the higher-precedence one silently wins.
+func TestValidateWarnings_ModuleGlobOverlap_PrefixCollision(t *testing.T) {
+	cfg := &Config{
+		Classifications: []ClassificationConfig{
+			{
+				Name: "major",
+				Rules: []RuleConfig{{
+					Description: "Cognitive accounts",
+					Resource:    []string{"azapi_resource"},
+					Module:      []string{"**.cognitive_account_foundry*"},
+				}},
+			},
+			{
+				Name: "limited",
+				Rules: []RuleConfig{{
+					Description: "Foundry connections",
+					Resource:    []string{"azapi_resource"},
+					Module:      []string{"**.cognitive_account_foundry_kv_connection*"},
+				}},
+			},
+		},
+		Precedence: []string{"major", "limited"},
+		Defaults:   &DefaultsConfig{Unclassified: "major", NoChanges: "major"},
+	}
+
+	warnings := ValidateWarnings(cfg)
+
+	var found *Warning
+	for i, w := range warnings {
+		if strings.Contains(w.Message, "module glob overlap") {
+			found = &warnings[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("expected module glob overlap warning, got: %v", warnings)
+	}
+	for _, want := range []string{"major", "limited", "Cognitive accounts", "Foundry connections"} {
+		if !strings.Contains(found.Message, want) {
+			t.Errorf("expected warning to mention %q, got: %s", want, found.Message)
+		}
+	}
+}
+
+// TestValidateWarnings_ModuleGlobOverlap_EscapedFix verifies that the
+// recommended fix — `**.foo\[*` instead of `**.foo*` — does NOT trigger the
+// overlap warning because the escaped `[` requires a literal bracket suffix
+// that the sibling pattern cannot satisfy.
+func TestValidateWarnings_ModuleGlobOverlap_EscapedFix(t *testing.T) {
+	cfg := &Config{
+		Classifications: []ClassificationConfig{
+			{
+				Name: "major",
+				Rules: []RuleConfig{{
+					Resource: []string{"azapi_resource"},
+					Module:   []string{`**.cognitive_account_foundry\[*`},
+				}},
+			},
+			{
+				Name: "limited",
+				Rules: []RuleConfig{{
+					Resource: []string{"azapi_resource"},
+					Module:   []string{`**.cognitive_account_foundry_kv_connection\[*`},
+				}},
+			},
+		},
+		Precedence: []string{"major", "limited"},
+		Defaults:   &DefaultsConfig{Unclassified: "major", NoChanges: "major"},
+	}
+
+	for _, w := range ValidateWarnings(cfg) {
+		if strings.Contains(w.Message, "module glob overlap") {
+			t.Errorf("escaped patterns should not overlap, got warning: %s", w.Message)
+		}
+	}
+}
+
+// TestValidateWarnings_ModuleGlobOverlap_DisjointPatterns ensures patterns
+// that genuinely match different addresses are not flagged.
+func TestValidateWarnings_ModuleGlobOverlap_DisjointPatterns(t *testing.T) {
+	cfg := &Config{
+		Classifications: []ClassificationConfig{
+			{
+				Name:  "critical",
+				Rules: []RuleConfig{{Resource: []string{"*"}, Module: []string{"**.production"}}},
+			},
+			{
+				Name:  "standard",
+				Rules: []RuleConfig{{Resource: []string{"*"}, Module: []string{"**.staging"}}},
+			},
+		},
+		Precedence: []string{"critical", "standard"},
+		Defaults:   &DefaultsConfig{Unclassified: "standard", NoChanges: "standard"},
+	}
+
+	for _, w := range ValidateWarnings(cfg) {
+		if strings.Contains(w.Message, "module glob overlap") {
+			t.Errorf("expected no overlap for disjoint patterns, got: %s", w.Message)
+		}
+	}
+}
+
+// TestValidateWarnings_ModuleGlobOverlap_SameClassification: overlap between
+// two rules in the same classification is fine — they assign the same label,
+// so the user has no decision to make.
+func TestValidateWarnings_ModuleGlobOverlap_SameClassification(t *testing.T) {
+	cfg := &Config{
+		Classifications: []ClassificationConfig{
+			{
+				Name: "major",
+				Rules: []RuleConfig{
+					{Resource: []string{"*"}, Module: []string{"**.cognitive_account_foundry*"}},
+					{Resource: []string{"*"}, Module: []string{"**.cognitive_account_foundry_kv_connection*"}},
+				},
+			},
+		},
+		Precedence: []string{"major"},
+		Defaults:   &DefaultsConfig{Unclassified: "major", NoChanges: "major"},
+	}
+
+	for _, w := range ValidateWarnings(cfg) {
+		if strings.Contains(w.Message, "module glob overlap") {
+			t.Errorf("expected no overlap warning within a single classification, got: %s", w.Message)
+		}
+	}
+}
+
+// TestValidateWarnings_ModuleGlobOverlap_TrivialPatterns: catch-alls like
+// `**` or `*` overlap with everything by definition; the unreachable-rule
+// warning already covers them, so the overlap detector should skip them.
+func TestValidateWarnings_ModuleGlobOverlap_TrivialPatterns(t *testing.T) {
+	cfg := &Config{
+		Classifications: []ClassificationConfig{
+			{
+				Name:  "critical",
+				Rules: []RuleConfig{{Resource: []string{"*"}, Module: []string{"**"}}},
+			},
+			{
+				Name:  "standard",
+				Rules: []RuleConfig{{Resource: []string{"*"}, Module: []string{"**.foo*"}}},
+			},
+		},
+		Precedence: []string{"critical", "standard"},
+		Defaults:   &DefaultsConfig{Unclassified: "standard", NoChanges: "standard"},
+	}
+
+	for _, w := range ValidateWarnings(cfg) {
+		if strings.Contains(w.Message, "module glob overlap") {
+			t.Errorf("trivial pattern `**` should be skipped by overlap detector, got: %s", w.Message)
+		}
+	}
+}
+
+func TestConcretizeModulePattern(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"**.cognitive_account_foundry*", "x.cognitive_account_foundryx"},
+		{"**.cognitive_account_foundry_kv_connection*", "x.cognitive_account_foundry_kv_connectionx"},
+		{`**.cognitive_account_foundry\[*`, "x.cognitive_account_foundry[x"},
+		{"**.foo.*", "x.foo.x"},
+		{"**.foo", "x.foo"},
+		{"**.foo?bar", "x.fooxbar"},
+		{"**.foo[abc]bar", "x.fooxbar"},
+		{"**.foo{bar,baz}", "x.foox"},
+	}
+	for _, c := range cases {
+		got := concretizeModulePattern(c.in)
+		if got != c.want {
+			t.Errorf("concretizeModulePattern(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/testdata/e2e/ignore-attributes-scoped/expected.json
+++ b/testdata/e2e/ignore-attributes-scoped/expected.json
@@ -1,5 +1,6 @@
 {
   "create": { "exit_code": 1, "classification": "standard" },
   "destroy": { "exit_code": 1, "classification": "standard" },
-  "plan_only": true
+  "plan_only": true,
+  "fixture_only": true
 }

--- a/testdata/e2e/run.sh
+++ b/testdata/e2e/run.sh
@@ -156,6 +156,9 @@ fi
 echo ""
 
 # --- Discover scenarios ---
+# Scenarios with `"fixture_only": true` in expected.json have no main.tf and
+# only run in fixture mode. Auto-skip them when running live Terraform unless
+# the user named them explicitly via -t.
 if [[ ${#TESTS[@]} -gt 0 ]]; then
   SCENARIOS=("${TESTS[@]}")
   for t in "${SCENARIOS[@]}"; do
@@ -168,9 +171,14 @@ else
   SCENARIOS=()
   for dir in "$E2E_DIR"/*/; do
     name="$(basename "$dir")"
-    if [[ -f "$dir/expected.json" ]]; then
-      SCENARIOS+=("$name")
+    if [[ ! -f "$dir/expected.json" ]]; then
+      continue
     fi
+    if [[ "$FIXTURES" == false ]] \
+       && [[ "$(jq -r '.fixture_only // false' "$dir/expected.json")" == "true" ]]; then
+      continue
+    fi
+    SCENARIOS+=("$name")
   done
 fi
 


### PR DESCRIPTION
Two unrelated fixes:

- The nightly Verify workflow failed for `ignore-attributes-scoped` because that scenario has no `main.tf` (it tests the scoped `ignore_attribute` feature against a hand-crafted update plan that cannot be replayed against live Azure). Mark it `fixture_only` and update the matrix discovery in verify.yml, ci.yml, and run.sh to skip such scenarios.

- Add a new validation warning when two rules in different classifications have overlapping module globs. The warning surfaces the bug from the workzones/aiwz audit where `**.cognitive_account_foundry*` silently matched `cognitive_account_foundry_kv_connection["foundry"]` and the higher-precedence classification won. Detection works by concretizing one pattern (replacing wildcards with placeholders, honoring escapes and skipping char-classes / brace alternations) and testing it against the other compiled glob.